### PR TITLE
feat: redesign header and nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,37 +4,73 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>자연 풍경 랜딩페이지</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Nanum+Myeongjo:wght@400&family=Zen+Old+Mincho&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+        h1 {
+            font-family: 'Zen Old Mincho', serif;
+            font-weight: 400;
+            font-size: 128px;
+        }
+        h2 {
+            font-family: 'Inter', sans-serif;
+            font-weight: 400;
+            font-size: 64px;
+        }
+        p {
+            font-weight: 400;
+            font-size: 24px;
+        }
+        .header-subtitle {
+            font-family: 'Nanum Myeongjo', serif;
+            font-size: 36px;
+        }
         .hero-image {
             background: url('assets/images/hero.jpg') no-repeat center/cover;
         }
         .gallery-image {
             background: url('assets/images/gallery1.jpg') no-repeat center/cover;
         }
-        /* 추가 갤러리 이미지 */
+        /* additional gallery images */
         .gallery-image:nth-child(2) { background-image: url('assets/images/gallery2.jpg'); }
         .gallery-image:nth-child(3) { background-image: url('assets/images/gallery3.jpg'); }
         .gallery-image:nth-child(4) { background-image: url('assets/images/gallery4.jpg'); }
+        #main-nav {
+            transition: background-color 0.3s, max-height 0.3s;
+        }
+        #main-nav .nav-item {
+            transition: color 0.3s;
+        }
     </style>
 </head>
-<body class="font-sans bg-gray-900 text-white">
+<body class="bg-gray-900 text-white">
     <!-- Header -->
-    <header class="bg-black bg-opacity-50 text-white py-4 sticky top-0 z-10">
-        <div class="container mx-auto flex justify-between items-center px-4">
-            <h1 class="text-3xl font-bold">加時沐</h1>
-            <nav>
-                <a href="#shop" class="mr-4 hover:underline">Shop</a>
-                <a href="#contact" class="hover:underline">Contact</a>
-            </nav>
-        </div>
+    <header class="bg-black bg-opacity-50 text-white text-center py-12">
+        <h1 class="mb-2">加時沐</h1>
+        <h2 class="header-subtitle">치유의 정원</h2>
     </header>
+
+    <!-- Navigation -->
+    <nav id="main-nav" class="w-[502px] mx-auto mt-4 bg-white text-black font-medium text-[20px] overflow-hidden">
+        <div class="flex justify-between items-center h-[86px] px-6">
+            <div class="nav-item cursor-pointer">가시림</div>
+            <div class="nav-item cursor-pointer">방문</div>
+            <div class="nav-item cursor-pointer">프로그램</div>
+            <div class="nav-item cursor-pointer">Shop</div>
+        </div>
+        <div id="submenu" class="hidden flex-col px-6 py-2 text-white text-[16px] font-medium" style="background-color: rgba(0,0,0,0.24);"></div>
+    </nav>
 
     <!-- Hero Section -->
     <section class="hero-image min-h-screen flex items-center justify-center text-center bg-black bg-opacity-50">
         <div>
-            <h2 class="text-5xl font-extrabold mb-4">수목원을 넘어 복합 문화 공간을 지향하다.</h2>
-            <p class="text-xl mb-6">2025년 봄, 약 4,000평 규모의 수목원과 힐링 공간, 문화 예술 공간이 결합된 복합 문화 공간이 문을 엽니다. 자연 속에서 힐링과 예술을 즐길 수 있는 특별한 장소입니다.</p>
+            <h2 class="mb-4">수목원을 넘어 복합 문화 공간을 지향하다.</h2>
+            <p class="mb-6">2025년 봄, 약 4,000평 규모의 수목원과 힐링 공간, 문화 예술 공간이 결합된 복합 문화 공간이 문을 엽니다. 자연 속에서 힐링과 예술을 즐길 수 있는 특별한 장소입니다.</p>
             <div class="relative w-16 h-16 mx-auto">
                 <div class="absolute inset-0 flex items-center justify-center bg-gray-800 rounded-full cursor-pointer hover:bg-gray-700">
                     ▶
@@ -47,7 +83,7 @@
     <section class="py-16 bg-gray-800">
         <div class="container mx-auto text-center px-4">
             <h3 class="text-3xl font-bold mb-6">제주 4호 민간정원</h3>
-            <p class="text-lg mb-4">2000년 설립 이후 약 20년간의 정원 조성 과정을 거쳐 2020년 7월에 정식 개원했습니다. 현재 약 4,000평 규모의 수목원과 힐링 공간, 문화 예술 공간이 결합된 복합 문화 공간으로 자리 잡았습니다. 자연과 예술이 어우러진 공간에서 힐링과 문화를 경험해 보세요.</p>
+            <p class="mb-4">2000년 설립 이후 약 20년간의 정원 조성 과정을 거쳐 2020년 7월에 정식 개원했습니다. 현재 약 4,000평 규모의 수목원과 힐링 공간, 문화 예술 공간이 결합된 복합 문화 공간으로 자리 잡았습니다. 자연과 예술이 어우러진 공간에서 힐링과 문화를 경험해 보세요.</p>
         </div>
     </section>
 
@@ -55,7 +91,7 @@
     <section class="py-16 bg-gray-900">
         <div class="container mx-auto text-center px-4">
             <h3 class="text-3xl font-bold mb-6">수목원 여덟 개 강의에서 체험 가능한 공간</h3>
-            <p class="text-lg mb-4">자연과 힐링, 예술이 결합된 공간에서 특별한 경험을 제공합니다. 다양한 테마의 공간을 통해 자연과 조화를 이루는 시간을 만끽하세요.</p>
+            <p class="mb-4">자연과 힐링, 예술이 결합된 공간에서 특별한 경험을 제공합니다. 다양한 테마의 공간을 통해 자연과 조화를 이루는 시간을 만끽하세요.</p>
             <div class="grid grid-cols-2 gap-4 mt-6 max-w-2xl mx-auto">
                 <div class="gallery-image h-48 rounded-lg"></div>
                 <div class="gallery-image h-48 rounded-lg"></div>
@@ -67,7 +103,44 @@
 
     <!-- Footer -->
     <footer class="bg-gray-800 py-6 text-center">
-        <p class="text-sm">&copy; 2025 加時 沐. All rights reserved.</p>
+        <p>&copy; 2025 加時 沐. All rights reserved.</p>
     </footer>
+
+    <script>
+        const nav = document.getElementById('main-nav');
+        const submenu = document.getElementById('submenu');
+        const navItems = nav.querySelectorAll('.nav-item');
+        const subpages = {
+            '가시림': ['공간 소개', '수목원 지도', '둘러보기'],
+            '방문': ['이용 안내', '오시는 길', '단체 문의'],
+            '프로그램': ['산책 명상', '명상', '원예'],
+            'Shop': ['All', '식물', '차']
+        };
+
+        navItems.forEach(item => {
+            item.addEventListener('mouseenter', () => {
+                const pages = subpages[item.textContent.trim()] || [];
+                submenu.innerHTML = pages.map(p => `<a href="#" class="block py-1">${p}</a>`).join('');
+                if (pages.length > 0) {
+                    submenu.classList.remove('hidden');
+                    const submenuHeight = submenu.scrollHeight;
+                    nav.style.maxHeight = (86 + submenuHeight) + 'px';
+                } else {
+                    submenu.classList.add('hidden');
+                    nav.style.maxHeight = '86px';
+                }
+                nav.style.backgroundColor = 'black';
+                navItems.forEach(i => i.style.color = 'black');
+                item.style.color = 'white';
+            });
+        });
+
+        nav.addEventListener('mouseleave', () => {
+            nav.style.maxHeight = '86px';
+            nav.style.backgroundColor = 'white';
+            navItems.forEach(i => i.style.color = 'black');
+            submenu.classList.add('hidden');
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Zen Old Mincho and Nanum Myeongjo alongside Inter and set default text styles
- Show 128px Zen Old Mincho title with Nanum Myeongjo subtitle
- Build 502×86 navigation bar that inverts colors and expands to reveal sub‑pages on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b4366e883218d7943227c5a09de