### PR TITLE
feat: redesign header with scroll motion

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,6 +9,157 @@
   overflow: hidden;
 }
 
+/* ===== Sticky header (gradient overlay + scroll motion) ===== */
+:root {
+  --hdr-transform-duration: 420ms;
+  --hdr-transform-ease: cubic-bezier(.22,.61,.36,1);
+  --hdr-color-duration: 1400ms;
+  --hdr-color-ease: ease-in-out;
+  --hdr-shadow: 0 10px 30px rgba(0,0,0,.06);
+  --gradient-direction: to bottom;
+  --gradient-hsl-values: 0, 0%, 0%;
+  --brand-left: 60px;
+  --brand-width: 100px;
+  --brand-gap: 300px;
+}
+
+@media (max-width: 768px) {
+  .brand-title { top: 12px; left: 16px; }
+  .site-header { padding-left: calc(16px + var(--brand-width) + 8px); }
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 30px 45px;
+  padding-left: calc(var(--brand-left) + var(--brand-width) + var(--brand-gap));
+  background: transparent;
+  color: #fff;
+  transition:
+    transform var(--hdr-transform-duration) var(--hdr-transform-ease),
+    opacity   var(--hdr-transform-duration) var(--hdr-transform-ease),
+    color     var(--hdr-color-duration) var(--hdr-color-ease);
+  will-change: transform, opacity, color;
+  isolation: isolate;
+}
+
+.site-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  opacity: 0;
+  transition: opacity var(--hdr-color-duration) var(--hdr-color-ease);
+  background-image: linear-gradient(
+    var(--gradient-direction),
+    hsla(var(--gradient-hsl-values), .80)   0%,
+    hsla(var(--gradient-hsl-values), .79)   8.3%,
+    hsla(var(--gradient-hsl-values), .761) 16.2%,
+    hsla(var(--gradient-hsl-values), .717) 23.9%,
+    hsla(var(--gradient-hsl-values), .66)  31.4%,
+    hsla(var(--gradient-hsl-values), .593) 38.6%,
+    hsla(var(--gradient-hsl-values), .518) 45.6%,
+    hsla(var(--gradient-hsl-values), .44)  52.3%,
+    hsla(var(--gradient-hsl-values), .36)  58.9%,
+    hsla(var(--gradient-hsl-values), .282) 65.2%,
+    hsla(var(--gradient-hsl-values), .207) 71.3%,
+    hsla(var(--gradient-hsl-values), .140) 77.4%,
+    hsla(var(--gradient-hsl-values), .083) 83.3%,
+    hsla(var(--gradient-hsl-values), .039) 89%,
+    hsla(var(--gradient-hsl-values), .010) 94.5%,
+    hsla(var(--gradient-hsl-values), 0)   100%
+  );
+}
+
+.site-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  opacity: 0;
+  transition: opacity var(--hdr-color-duration) var(--hdr-color-ease);
+  background: rgba(255,255,255,.96);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--hdr-shadow);
+}
+
+.site-header.is-hidden   { transform: translate3d(0,-100%,0); opacity: 0; }
+.site-header.is-gradient { color: #fff; }
+.site-header.is-gradient::before { opacity: 1; }
+.site-header.is-scrolled { color: #111; }
+.site-header.is-scrolled::after { opacity: 1; }
+
+.brand-title {
+  position: fixed;
+  top: 30px;
+  left: var(--brand-left);
+  z-index: 2000;
+  display: block;
+  font-weight: 400;
+  font-size: clamp(20px, 2.6vw, 20px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: #fff;
+  mix-blend-mode: difference;
+  transition: color var(--hdr-color-duration) var(--hdr-color-ease);
+}
+
+html.hdr-overlay .brand-title { mix-blend-mode: normal; }
+.site-header.is-scrolled ~ .brand-title { color: #111; }
+.site-header.is-gradient ~ .brand-title { color: #fff; }
+
+.site-header .navbar {
+  position: static;
+  top: auto;
+  right: auto;
+  width: auto;
+  max-width: none;
+  min-height: auto;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.site-header nav a {
+  margin: 0 12px;
+  position: relative;
+  text-decoration: none;
+  color: inherit;
+}
+
+.site-header nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 1px;
+  background: currentColor;
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform .25s;
+}
+
+.site-header nav a:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header,
+  .site-header::before,
+  .site-header::after,
+  .brand-title {
+    transition: none !important;
+  }
+}
+
 /* ===== Individual Page Head Panel (responsive height) ===== */
 .shop-panel {
   position: relative;

--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -1,24 +1,17 @@
-<header class="head-panel">
-  <!-- Mobile menu button (first child) -->
+<header class="site-header" data-header>
+  <!-- Mobile menu button -->
   <button
     class="nav-toggle"
     type="button"
     aria-expanded="false"
     aria-controls="main-menu"
-    aria-label="메인 메뉴 열기/닫기"
-  >
+    aria-label="메인 메뉴 열기/닫기">
     <span class="sr-only">메뉴</span>
     <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
     </svg>
   </button>
 
-  <div class="website-title">
-    <h1 class="title">加 時 林</h1>
-    <h2 class="subtitle">치유의 정원</h2>
-  </div>
-
-  <!-- Navigation Bar -->
   <nav class="navbar" role="navigation" aria-label="Main navigation">
     <ul id="main-menu" class="nav-main">
       <li class="nav-item" tabindex="0" aria-haspopup="true" aria-expanded="false">
@@ -49,3 +42,29 @@
     </ul>
   </nav>
 </header>
+<a class="brand-title" href="/">加 時 林 | 치유의 정원</a>
+<script>
+(function(){
+  const header = document.querySelector('[data-header]');
+  if (!header) return;
+  let lastY = window.scrollY;
+  const HYST = 3;
+  const setHidden = () => { header.classList.add('is-hidden'); header.classList.remove('is-scrolled','is-gradient'); document.documentElement.classList.remove('hdr-overlay'); };
+  const setWhite = () => { header.classList.remove('is-hidden'); header.classList.add('is-scrolled'); header.classList.remove('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+  const setGradient = () => { header.classList.remove('is-hidden'); header.classList.remove('is-scrolled'); header.classList.add('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+  function onScroll(){
+    const y = window.scrollY;
+    const goingDown = y > lastY + HYST;
+    const goingUp = y < lastY - HYST;
+    if (goingDown){
+      if (y > 0) setHidden();
+    } else if (goingUp){
+      if (y <= 0) setGradient();
+      else setWhite();
+    }
+    lastY = y;
+  }
+  if (window.scrollY <= 0) setGradient(); else setHidden();
+  addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
+})();
+</script>

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -1,22 +1,18 @@
-<!-- Mobile menu button (first child) -->
-<button
-  class="nav-toggle"
-  type="button"
-  aria-expanded="false"
-  aria-controls="main-menu"
-  aria-label="메인 메뉴 열기/닫기"
->
-  <span class="sr-only">메뉴</span>
-  <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-    <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-  </svg>
-</button>
+<header class="site-header" data-header>
+  <!-- Mobile menu button -->
+  <button
+    class="nav-toggle"
+    type="button"
+    aria-expanded="false"
+    aria-controls="main-menu"
+    aria-label="메인 메뉴 열기/닫기">
+    <span class="sr-only">메뉴</span>
+    <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    </svg>
+  </button>
 
-<!-- Top bar -->
-<div class="site-header-bar">
-  <h1 class="site-title left">加 時 林</h1>
-  <h2 class="site-subtitle left">치유의 정원</h2>
-  <nav class="navbar transparent" role="navigation" aria-label="Main navigation">
+  <nav class="navbar" role="navigation" aria-label="Main navigation">
     <ul id="main-menu" class="nav-main">
       <li class="nav-item" tabindex="0" aria-haspopup="true" aria-expanded="false">
         소개
@@ -45,9 +41,30 @@
       <li class="nav-item" tabindex="0"><a href="shop.html">Shop</a></li>
     </ul>
   </nav>
-</div>
-
-<!-- Centered page heading -->
-<div class="site-header-center">
-  <h1 class="page-heading"></h1>
-</div>
+</header>
+<a class="brand-title" href="/">加 時 林 | 치유의 정원</a>
+<script>
+(function(){
+  const header = document.querySelector('[data-header]');
+  if (!header) return;
+  let lastY = window.scrollY;
+  const HYST = 3;
+  const setHidden = () => { header.classList.add('is-hidden'); header.classList.remove('is-scrolled','is-gradient'); document.documentElement.classList.remove('hdr-overlay'); };
+  const setWhite = () => { header.classList.remove('is-hidden'); header.classList.add('is-scrolled'); header.classList.remove('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+  const setGradient = () => { header.classList.remove('is-hidden'); header.classList.remove('is-scrolled'); header.classList.add('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+  function onScroll(){
+    const y = window.scrollY;
+    const goingDown = y > lastY + HYST;
+    const goingUp = y < lastY - HYST;
+    if (goingDown){
+      if (y > 0) setHidden();
+    } else if (goingUp){
+      if (y <= 0) setGradient();
+      else setWhite();
+    }
+    lastY = y;
+  }
+  if (window.scrollY <= 0) setGradient(); else setHidden();
+  addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
+})();
+</script>

--- a/shop.html
+++ b/shop.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="shop-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/공간소개.html
+++ b/공간소개.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="intro-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/단체문의.html
+++ b/단체문의.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="visit-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/둘러보기.html
+++ b/둘러보기.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="intro-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/명상.html
+++ b/명상.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="program-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/산책명상.html
+++ b/산책명상.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="program-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/수목원지도.html
+++ b/수목원지도.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="intro-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/오시는길.html
+++ b/오시는길.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="visit-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/원예.html
+++ b/원예.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="program-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/이용안내.html
+++ b/이용안내.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <header id="site-header" class="visit-panel" data-include="partials/header-site.html"></header>
+    <div id="site-header" data-include="partials/header-site.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">


### PR DESCRIPTION
## Summary
- Revamp site and landing headers with single-line title "加 時 林 | 치유의 정원" and scroll-driven visibility
- Add new CSS for sticky header with gradient and white overlays and fixed brand title
- Replace page header containers to load the new partial structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcddfcfdc88321a0e11f4cecb140b1