### PR TITLE
Add hero slideshow to site headers

### DIFF
--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -43,6 +43,26 @@
   </nav>
 </header>
 <a class="brand-title" href="/">加 時 林 | 치유의 정원</a>
+<section class="hero-slideshow">
+  <div class="embla">
+    <div class="embla__viewport">
+      <div class="embla__container">
+        <div class="embla__slide">
+          <img src="https://images.unsplash.com/photo-1756908604030-04861dc79820?q=80&amp;w=2071&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.1.0&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Nature landscape placeholder">
+          <div class="embla__overlay">
+            <h1>Placeholder title</h1>
+            <p>Placeholder subtitle</p>
+            <div class="embla__controls">
+              <button class="embla__prev" aria-label="Previous slide"></button>
+              <button class="embla__next" aria-label="Next slide"></button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
 <script>
 (function(){
   const header = document.querySelector('[data-header]');

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -43,6 +43,26 @@
   </nav>
 </header>
 <a class="brand-title" href="/">加 時 林 | 치유의 정원</a>
+<section class="hero-slideshow">
+  <div class="embla">
+    <div class="embla__viewport">
+      <div class="embla__container">
+        <div class="embla__slide">
+          <img src="https://images.unsplash.com/photo-1756908604030-04861dc79820?q=80&amp;w=2071&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.1.0&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Nature landscape placeholder">
+          <div class="embla__overlay">
+            <h1>Placeholder title</h1>
+            <p>Placeholder subtitle</p>
+            <div class="embla__controls">
+              <button class="embla__prev" aria-label="Previous slide"></button>
+              <button class="embla__next" aria-label="Next slide"></button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
 <script>
 (function(){
   const header = document.querySelector('[data-header]');


### PR DESCRIPTION
## Summary
- Add hero slideshow with Embla markup to main and landing headers
- Load Embla Carousel from CDN for hero slides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0622f44c83218b1870ddab53cad7