### PR TITLE
refactor: centralize header scroll behavior

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -148,6 +148,35 @@
     window.addEventListener('resize', onResize, { passive: true });
   }
 
+
+  // ---------- Header scroll behavior ----------
+  function initHeaderScroll() {
+    const header = document.querySelector('[data-header]');
+    if (!header || !markOnce(header, 'scrollBound')) return;
+
+    let lastY = window.scrollY;
+    const HYST = 3;
+    const setHidden = () => { header.classList.add('is-hidden'); header.classList.remove('is-scrolled','is-gradient'); document.documentElement.classList.remove('hdr-overlay'); };
+    const setWhite = () => { header.classList.remove('is-hidden'); header.classList.add('is-scrolled'); header.classList.remove('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+    const setGradient = () => { header.classList.remove('is-hidden'); header.classList.remove('is-scrolled'); header.classList.add('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
+
+    function onScroll(){
+      const y = window.scrollY;
+      const goingDown = y > lastY + HYST;
+      const goingUp = y < lastY - HYST;
+      if (goingDown){
+        if (y > 0) setHidden();
+      } else if (goingUp){
+        if (y <= 0) setGradient();
+        else setWhite();
+      }
+      lastY = y;
+    }
+    if (window.scrollY <= 0) setGradient();
+    else setHidden();
+    window.addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
+  }
+
   // ---------- Hero carousel ----------
   function initHeroCarousel() {
     const hero = document.querySelector('.embla');
@@ -169,6 +198,7 @@
     initNavDropdowns();
     initMobileMenu();
     initNavResizeGuard();
+    initHeaderScroll();
     initHeroCarousel();
   }
 

--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -63,29 +63,3 @@
   </div>
 </section>
 <script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
-<script>
-(function(){
-  const header = document.querySelector('[data-header]');
-  if (!header) return;
-  let lastY = window.scrollY;
-  const HYST = 3;
-  const setHidden = () => { header.classList.add('is-hidden'); header.classList.remove('is-scrolled','is-gradient'); document.documentElement.classList.remove('hdr-overlay'); };
-  const setWhite = () => { header.classList.remove('is-hidden'); header.classList.add('is-scrolled'); header.classList.remove('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
-  const setGradient = () => { header.classList.remove('is-hidden'); header.classList.remove('is-scrolled'); header.classList.add('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
-  
-  function onScroll(){
-    const y = window.scrollY;
-    const goingDown = y > lastY + HYST;
-    const goingUp = y < lastY - HYST;
-    if (goingDown){
-      if (y > 0) setHidden();
-    } else if (goingUp){
-      if (y <= 0) setGradient();
-      else setWhite();
-    }
-    lastY = y;
-  }
-  if (window.scrollY <= 0) setGradient(); else setHidden();
-  addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
-})();
-</script>

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -63,28 +63,3 @@
   </div>
 </section>
 <script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
-<script>
-(function(){
-  const header = document.querySelector('[data-header]');
-  if (!header) return;
-  let lastY = window.scrollY;
-  const HYST = 3;
-  const setHidden = () => { header.classList.add('is-hidden'); header.classList.remove('is-scrolled','is-gradient'); document.documentElement.classList.remove('hdr-overlay'); };
-  const setWhite = () => { header.classList.remove('is-hidden'); header.classList.add('is-scrolled'); header.classList.remove('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
-  const setGradient = () => { header.classList.remove('is-hidden'); header.classList.remove('is-scrolled'); header.classList.add('is-gradient'); document.documentElement.classList.add('hdr-overlay'); };
-  function onScroll(){
-    const y = window.scrollY;
-    const goingDown = y > lastY + HYST;
-    const goingUp = y < lastY - HYST;
-    if (goingDown){
-      if (y > 0) setHidden();
-    } else if (goingUp){
-      if (y <= 0) setGradient();
-      else setWhite();
-    }
-    lastY = y;
-  }
-  if (window.scrollY <= 0) setGradient(); else setHidden();
-  addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
-})();
-</script>


### PR DESCRIPTION
## Summary
- remove duplicate inline header scroll scripts
- move header scroll behavior into main.js and initialize after partials load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4309a35c83218a30fc4c797ab981