### PR TITLE
fix: show header when scrolling up from body

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -151,7 +151,7 @@
 
   // ---------- Header scroll behavior ----------
   function initHeaderScroll() {
-    
+
     const header = document.querySelector('[data-header]');
     if (!header || !markOnce(header, 'scrollBound')) return;
 
@@ -165,19 +165,22 @@
 
     function onScroll(){
       const y = getScrollY();
-      const delta = y - lastY;
-      if (Math.abs(delta) > HYST) {
-        if (delta > 0 && y > 0) {
-          setHidden();
-        } else if (delta < 0) {
-          if (y <= 0) setGradient();
-          else setWhite();
-        }
-        lastY = y;
+      const goingDown = y > lastY + HYST;
+      const goingUp = y < lastY - HYST;
+
+      if (goingDown){
+        if (y > 0) setHidden();
+      } else if (goingUp){
+        if (y <= 0) setGradient();
+        else setWhite();
       }
+
+      lastY = y;
     }
+
     if (getScrollY() <= 0) setGradient();
     else setHidden();
+
     window.addEventListener('scroll', () => { requestAnimationFrame(onScroll); }, { passive: true });
   }
 


### PR DESCRIPTION
## Summary
- ensure site header toggles visibility immediately based on scroll direction

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa45c29c8321a09c908253039568