### PR TITLE
Add logo image to brand title

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -90,14 +90,22 @@
   top: 30px;
   left: var(--brand-left);
   z-index: 2000;
-  display: block;
+  display: flex;
+  align-items: center;
   font-weight: 400;
   font-size: clamp(20px, 2.6vw, 20px);
   line-height: 1;
   letter-spacing: 0.02em;
   color: #fff;
   mix-blend-mode: difference;
+  text-decoration: none;
   transition: color var(--hdr-color-duration) var(--hdr-color-ease);
+}
+
+.brand-logo {
+  width: 32px;
+  height: 32px;
+  margin-right: 8px;
 }
 
 

--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -25,6 +25,6 @@
   --gradient-direction: to bottom;
   --gradient-hsl-values: 0, 0%, 0%;
   --brand-left: 60px;
-  --brand-width: 100px;
+  --brand-width: 180px;
   --brand-gap: 300px;
 }

--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -1,4 +1,7 @@
-<a class="brand-title" href="/gasirim.github.io/">加 時 林 | 치유의 정원</a>
+<a class="brand-title" href="/gasirim.github.io/">
+  <img src="assets/img/가시림_나무.png" alt="가시림 로고" class="brand-logo" />
+  <span class="brand-text">加 時 林 | 치유의 정원</span>
+</a>
 <section class="hero-slideshow">
   <div class="embla">
     <div class="embla__viewport">

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -42,7 +42,10 @@
     </ul>
   </nav>
 </header>
-<a class="brand-title" href="/gasirim.github.io/">加 時 林 | 치유의 정원</a>
+<a class="brand-title" href="/gasirim.github.io/">
+  <img src="assets/img/가시림_나무.png" alt="가시림 로고" class="brand-logo" />
+  <span class="brand-text">加 時 林 | 치유의 정원</span>
+</a>
 <section class="hero-slideshow">
   <div class="embla">
     <div class="embla__viewport">


### PR DESCRIPTION
## Summary
- Display brand logo alongside site name in header partials using a local image.
- Style brand title as a flex container and add sizing for the logo.
- Adjust CSS variable for brand width to accommodate new logo.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee57a33cc8321be61dc95d7becf43