### PR TITLE
style: stretch intro tabs across full width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1069,12 +1069,26 @@
   position: relative;
   width: 100%;
   display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 24px;
-  height: 86px;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 0;
+  height: 81px;
   background: #fff;
   padding: 0;
+}
+
+.intro-tabs .tab-button {
+  flex: 1 1 0;
+  width: auto;
+  height: 100%;
+  border: none;
+  background: #fff;
+  color: #454545;
+}
+
+.intro-tabs .tab-button.active {
+  background: #e5e5e5;
+  color: #454545;
 }
 
 .space-tabs {


### PR DESCRIPTION
## Summary
- distribute intro page tabs evenly across the width
- give active tab a light background while removing borders from intro tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c40f97ac448321a6b34beeefd3c906