### PR TITLE
Replace header carousel with intro video

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -203,6 +203,83 @@
   height: 100%;
 }
 
+.hero-slideshow--video {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: #000;
+}
+
+.hero-video__container {
+  position: relative;
+  height: 100%;
+}
+
+.hero-slideshow--video .intro-hero {
+  display: block;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+.hero-slideshow--video .intro-video {
+  width: 100%;
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: 0;
+  box-shadow: none;
+  object-fit: cover;
+}
+
+.hero-slideshow--video .intro-video-play {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.hero-slideshow--video .intro-video-play:hover,
+.hero-slideshow--video .intro-video-play:focus-visible {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.hero-video__overlay {
+  flex-wrap: nowrap;
+  align-items: flex-end;
+  gap: clamp(1rem, 4vw, 2.5rem);
+}
+
+.hero-video__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  justify-items: end;
+}
+
+.hero-video__list a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.9rem;
+  opacity: 0.65;
+  transition: opacity 200ms ease;
+}
+
+.hero-video__list a:hover,
+.hero-video__list a:focus-visible {
+  opacity: 0.9;
+}
+
+@media (max-width: 768px) {
+  .hero-video__overlay {
+    align-items: flex-start;
+  }
+
+  .hero-video__list {
+    justify-items: start;
+    text-align: left;
+  }
+}
+
 .embla__slide {
   flex: 0 0 100%;
   position: relative;
@@ -806,12 +883,8 @@
 
 .intro-gallery {
   position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
   width: 100%;
   margin: var(--section-gap) auto;
-  gap: clamp(12px, 2vw, 28px);
   background: transparent;
 }
 
@@ -849,7 +922,8 @@
 .gimg-c { background-image: url('../img/가든센터.jpg'); }
 
 .intro-gallery-nav {
-  position: relative;
+  position: absolute;
+  top: clamp(12px, 3vw, 36px);
   display: grid;
   place-items: center;
   width: clamp(48px, 6vw, 72px);
@@ -859,8 +933,12 @@
   color: #fff;
   cursor: pointer;
   outline: none;
+  z-index: 2;
   transition: transform 220ms ease;
 }
+
+.intro-gallery-nav--prev { left: clamp(12px, 3vw, 36px); }
+.intro-gallery-nav--next { right: clamp(12px, 3vw, 36px); }
 
 .intro-gallery-nav::before {
   content: "";

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -316,11 +316,6 @@
         startAutoplay();
       });
 
-      gallery.addEventListener('mouseenter', stopAutoplay);
-      gallery.addEventListener('mouseleave', startAutoplay);
-      gallery.addEventListener('focusin', stopAutoplay);
-      gallery.addEventListener('focusout', startAutoplay);
-
       const onVisibilityChange = () => {
         if (document.hidden) {
           stopAutoplay();

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -5,49 +5,29 @@
     <span class="brand-tagline">치유의 정원</span>
   </span> -->
 </a>
-<section class="hero-slideshow">
-  <div class="embla">
-    <div class="embla__viewport">
-      <div class="embla__container">
-        <div class="embla__slide">
-          <img src="./assets/img/main.jpg" alt="Slide 1">
-        </div>
-        <div class="embla__slide">
-          <img src="./assets/img/main.jpg" alt="Slide 2">
-        </div>
-        <div class="embla__slide">
-          <img src="./assets/img/main.jpg" alt="Slide 3">
-        </div>
-        <div class="embla__slide">
-          <img src="./assets/img/main.jpg" alt="Slide 4">
-        </div>
-        <div class="embla__slide">
-          <img src="./assets/img/main.jpg" alt="Slide 5">
-        </div>
-      </div>
+<section class="hero-slideshow hero-slideshow--video">
+  <div class="hero-video__container">
+    <div class="intro-hero parallax" data-video>
+      <video class="intro-video" preload="auto" playsinline webkit-playsinline disablePictureInPicture controlsList="nodownload noplaybackrate noremoteplayback nofullscreen">
+        <source src="./assets/video/gasirim.mp4" type="video/mp4">
+        비디오를 재생할 수 없는 환경입니다.
+      </video>
+      <button class="intro-video-play" type="button" aria-label="영상 재생">
+        <span aria-hidden="true"></span>
+      </button>
     </div>
-    <div class="embla__overlay">
+    <div class="embla__overlay hero-video__overlay">
       <div class="embla__copy">
         <h1>제주가 품은 정원, 마음을 여는 공간</h1>
         <p><span class="text-variable">제주 민간 4호 정원, 가시림</span></p>
       </div>
-      <div class="embla__asset-text">
-        <p class="asset-text is-active" data-index="0"><a href="/gasirim.github.io/">오름 정원</a></p>
-        <p class="asset-text" data-index="1"><a href="/gasirim.github.io/">메타세쿼이어 숲</a></p>
-        <p class="asset-text" data-index="2"><a href="/gasirim.github.io/">팜파스그라스 길</a></p>
-        <p class="asset-text" data-index="3"><a href="/gasirim.github.io/">곶자왈</a></p>
-        <p class="asset-text" data-index="4"><a href="/gasirim.github.io/">수국 정원</a></p>
-      </div>
-      <div class="embla__controls">
-        <button class="embla__prev" aria-label="Previous slide">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 20" fill="currentColor"><path d="M11.77 1.77 10 0 0 10l10 10 1.77-1.77L3.54 10l8.23-8.23Z"/></svg>
-        </button>
-        <button class="embla__next" aria-label="Next slide">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 20" fill="currentColor"><path d="M0 18.23 1.77 20l10-10-10-10L0 1.77 8.23 10 0 18.23Z"/></svg>
-        </button>
-      </div>
+      <ul class="hero-video__list">
+        <li><a href="/gasirim.github.io/">오름 정원</a></li>
+        <li><a href="/gasirim.github.io/">메타세쿼이어 숲</a></li>
+        <li><a href="/gasirim.github.io/">팜파스그라스 길</a></li>
+        <li><a href="/gasirim.github.io/">곶자왈</a></li>
+        <li><a href="/gasirim.github.io/">수국 정원</a></li>
+      </ul>
     </div>
   </div>
 </section>
-<script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
-<script src="https://unpkg.com/embla-carousel-autoplay/embla-carousel-autoplay.umd.js" defer></script>


### PR DESCRIPTION
## Summary
- replace the inner-page header carousel with the intro video and supporting overlay content
- add styles that stretch the intro video full height and present quick links beside the overlay copy
- reposition intro gallery controls over the viewport and keep its autoplay running continuously

## Testing
- Manual verification in browser (shop.html)


------
https://chatgpt.com/codex/tasks/task_e_68d990faeb6883218539ff70a97c8d52