### PR TITLE
Revamp gallery styling and shop catalog

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -882,6 +882,8 @@
 }
 
 .intro-gallery {
+  --intro-gallery-gap: clamp(8px, 1.6vw, 28px);
+  --intro-gallery-visible: 1;
   position: relative;
   width: 100%;
   margin: var(--section-gap) auto;
@@ -891,14 +893,14 @@
 .intro-gallery-viewport {
   position: relative;
   overflow: hidden;
-  width: 100%;
+  width: min(1180px, 94vw);
+  margin: 0 auto;
 }
 
 .intro-gallery-track {
   display: flex;
-  gap: 0;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: flex-start;
   transform: translate3d(0, 0, 0);
   transition: transform 600ms ease;
   will-change: transform;
@@ -908,76 +910,104 @@
   transition: none !important;
 }
 
+.intro-gallery-track > .gimg {
+  flex: 0 0 calc(
+    (100% - (var(--intro-gallery-visible) - 1) * var(--intro-gallery-gap)) /
+    var(--intro-gallery-visible)
+  );
+  margin-right: var(--intro-gallery-gap);
+}
+
+.intro-gallery-track > .gimg:last-child {
+  margin-right: 0;
+}
+
 .gimg {
-  flex: 0 0 var(--intro-gallery-item-width, clamp(180px, 24vw, 260px));
-  width: var(--intro-gallery-item-width, clamp(180px, 24vw, 260px));
-  aspect-ratio: 4 / 5;
+  width: 100%;
+  aspect-ratio: 3 / 4;
   background: center/cover no-repeat;
-  border-radius: 12px;
+  border-radius: 18px;
+  box-shadow: 0 25px 40px rgba(17, 17, 17, 0.16);
 }
 
 /* Gallery tiles — scale but never too small or too huge */
 .gimg-a { background-image: url('../img/가든센터.jpg'); }
-.gimg-b { background-image: url('../img/가든센터.jpg'); }
-.gimg-c { background-image: url('../img/가든센터.jpg'); }
+.gimg-b { background-image: url('../img/유리온실.jpg'); }
+.gimg-c { background-image: url('../img/유리온실2.jpg'); }
+.gimg-d { background-image: url('../img/카페.jpg'); }
 
 .intro-gallery-nav {
   position: absolute;
-  top: clamp(12px, 3vw, 36px);
+  top: 50%;
+  transform: translateY(-50%);
   display: grid;
   place-items: center;
   width: clamp(48px, 6vw, 72px);
   aspect-ratio: 1;
-  border: none;
-  background: none;
-  color: #fff;
+  border-radius: 999px;
+  border: 1px solid rgba(17, 17, 17, 0.08);
+  background: rgba(255, 255, 255, 0.92);
+  color: #222;
   cursor: pointer;
   outline: none;
   z-index: 2;
-  transition: transform 220ms ease;
+  box-shadow: 0 18px 40px rgba(17, 17, 17, 0.14);
+  transition: transform 220ms ease, box-shadow 220ms ease, background 220ms ease;
 }
+
+.intro-gallery-nav::before { content: none; }
 
 .intro-gallery-nav--prev { left: clamp(12px, 3vw, 36px); }
 .intro-gallery-nav--next { right: clamp(12px, 3vw, 36px); }
 
-.intro-gallery-nav::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.62);
-  transition: background 220ms ease, transform 220ms ease, opacity 220ms ease;
-}
-
-.intro-gallery-nav--prev::before {
-  clip-path: polygon(100% 0, 58% 0, 0 50%, 58% 100%, 100% 100%, 100% 65%, 40% 50%, 100% 35%);
-}
-
-.intro-gallery-nav--next::before {
-  clip-path: polygon(0 0, 42% 0, 100% 50%, 42% 100%, 0 100%, 0 65%, 60% 50%, 0 35%);
-}
-
 .intro-gallery-nav svg {
-  position: relative;
-  z-index: 1;
-  width: clamp(16px, 2.5vw, 24px);
-  height: clamp(16px, 2.5vw, 24px);
-}
-
-.intro-gallery-nav:hover::before,
-.intro-gallery-nav:focus-visible::before {
-  background: rgba(0, 0, 0, 0.78);
+  width: clamp(20px, 2.8vw, 32px);
+  height: clamp(20px, 2.8vw, 32px);
 }
 
 .intro-gallery-nav:hover,
 .intro-gallery-nav:focus-visible {
-  transform: scale(1.04);
-  outline: 3px solid rgba(255, 255, 255, 0.65);
+  transform: translateY(calc(-50% - 2px)) scale(1.04);
+  background: #fff;
+  box-shadow: 0 22px 45px rgba(17, 17, 17, 0.18);
 }
 
 .intro-gallery-nav:disabled {
-  opacity: 0.4;
-  cursor: default;
-  transform: none;
+  opacity: 0.15;
+  cursor: not-allowed;
+  transform: translateY(-50%);
+  box-shadow: none;
+}
+
+@media (min-width: 640px) {
+  .intro-gallery { --intro-gallery-visible: 2; }
+}
+
+@media (min-width: 900px) {
+  .intro-gallery { --intro-gallery-visible: 3; }
+}
+
+@media (min-width: 1100px) {
+  .intro-gallery {
+    --intro-gallery-visible: 4;
+  }
+
+  .intro-gallery-viewport {
+    overflow: visible;
+  }
+
+  .intro-gallery-track {
+    justify-content: center;
+    transform: none !important;
+  }
+
+  .intro-gallery-track.is-instant {
+    transform: none !important;
+  }
+
+  .intro-gallery-nav {
+    display: none;
+  }
 }
 
 .intro-img-wide {
@@ -1067,12 +1097,183 @@
   position: relative;
   width: 89%;
   max-width: 1280px;
-  min-height: auto;    
+  min-height: auto;
   margin: var(--section-gap) auto;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, auto);
   gap: clamp(16px, 3vw, 40px) 2%;
+}
+
+/* ===== Shop page ===== */
+.shop-main {
+  padding: clamp(64px, 12vw, 144px) clamp(20px, 7vw, 120px) clamp(120px, 16vw, 200px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(72px, 12vw, 160px);
+}
+
+.shop-overview {
+  display: flex;
+  justify-content: center;
+}
+
+.shop-overview__inner {
+  width: min(720px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.shop-overview__eyebrow {
+  font-size: 0.875rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: #828282;
+}
+
+.shop-overview__title {
+  font-size: clamp(32px, 5vw, 56px);
+  line-height: 1.12;
+  font-weight: 400;
+}
+
+.shop-overview__description {
+  font-size: clamp(18px, 2.4vw, 22px);
+  line-height: 1.6;
+  color: #4f4f4f;
+}
+
+.shop-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 6vw, 60px);
+}
+
+.shop-catalog__header {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2vw, 24px);
+  align-items: flex-start;
+}
+
+.shop-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.shop-filter {
+  padding: 10px 28px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: #fff;
+  color: #111;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+}
+
+.shop-filter:is(:hover, :focus-visible) {
+  background: #111;
+  color: #fff;
+  border-color: #111;
+}
+
+.shop-filter.is-active {
+  background: #111;
+  color: #fff;
+  border-color: #111;
+}
+
+.shop-note {
+  font-size: 0.95rem;
+  color: #828282;
+}
+
+.shop-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(28px, 5vw, 48px);
+}
+
+.product-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.product-card__media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 618 / 667;
+  background: #f7f7f7;
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+.product-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 320ms ease;
+}
+
+.product-card__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.product-card__title {
+  font-size: clamp(22px, 3.4vw, 26px);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.product-card__description {
+  font-size: clamp(18px, 2.6vw, 20px);
+  color: #828282;
+  line-height: 1.5;
+}
+
+.product-card__price {
+  margin-top: 4px;
+  font-size: clamp(18px, 2.6vw, 20px);
+  font-weight: 500;
+  text-align: right;
+}
+
+.product-card:hover .product-card__media img,
+.product-card:focus-visible .product-card__media img {
+  transform: scale(1.04);
+}
+
+@media (min-width: 768px) {
+  .shop-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .product-card__price {
+    align-self: flex-end;
+  }
+}
+
+@media (min-width: 1100px) {
+  .shop-main {
+    padding-top: clamp(96px, 14vw, 180px);
+  }
+
+  .shop-catalog__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .shop-note {
+    font-size: 1rem;
+  }
 }
 
 /* ===== for 둘러보기 page ===== */

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/shop.html
+++ b/shop.html
@@ -25,62 +25,97 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
-
-    <!-- 가시림 소개 -->
-    <section class="body-container" aria-labelledby="intro-heading">
-      <h2 id="intro-heading" class="sr-only">가시림 소개</h2>
-
-      <div class="article article-container reveal from-up">
-        <h3 class="h center">수목원을 넘어 복합 문화 공간을 지향하다.</h3>
-        <p class="p center">가시림은 제주 토박이 조경가가 30년 이상의 경력으로 직접 설계·조성한 4,000평 규모의 민간 수목원이며, 원예·명상·예술 등 다양한 문화 프로그램을 운영하는 복합 문화 공간이다.</p>
-      </div>
-
-      <div class="intro-hero reveal parallax from-up"></div>
-
-
-      <div class="article article-container reveal from-left">
-        <h3 class="h left">제주 4호 민간정원</h3>
-        <p class="p left">가시림 수목원은 정부에 등록된 제주 4호 민간정원으로 2023년 12월에 오픈했으며 <b>14개의 정원·숲·길</b>로 구성되어 있다. <b>200년 이상 된 수목</b>이 다수 존재하며, 단순한 포토스팟 조형물이 아닌 진정성 있는 식물 배치 철학을 바탕으로 운영된다. 대표가 매일 아침 직접 나와 세심하게 관리함으로써 사계절 각기 다른 경관을 제공하며, 한 곳에서 다양한 <b>희귀 식물</b>을 감상할 수 있는 독보적인 수목원으로 자리매김하고 있다.</p>
-      </div>
-
-      <section class="intro-gallery reveal from-up" aria-label="가시림 이미지 갤러리" data-gallery>
-        <button class="intro-gallery-nav intro-gallery-nav--prev" type="button" aria-label="이전 사진" data-gallery-prev>
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
-          </svg>
-        </button>
-        <div class="intro-gallery-viewport">
-          <div class="intro-gallery-track">
-            <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
-            <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
-            <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
-          </div>
+    <main class="shop-main" aria-labelledby="shop-heading">
+      <section class="shop-overview">
+        <div class="shop-overview__inner">
+          <p class="shop-overview__eyebrow">Shop</p>
+          <h2 class="shop-overview__title" id="shop-heading">자연을 닮은 오브제로 공간을 채우다</h2>
+          <p class="shop-overview__description">가시림의 명상과 원예 프로그램에서 영감을 받은 굿즈와 클래스를 엄선했습니다. 감각을 깨우는 수업과 숍 아이템을 통해 일상의 시간을 특별하게 채워보세요.</p>
         </div>
-        <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="m8.59 7.41 1.41-1.41 6 6-6 6-1.41-1.41L13.17 12z" fill="currentColor" />
-          </svg>
-        </button>
       </section>
 
-      <div class="article article-container reveal from-right">
-        <h3 class="h right">수목원은 어떻게 감상해야 하는가</h3>
-        <p class="p right">가시림은 단순한 수목 감상을 넘어, 자연 속에서 오감을 열고 자신을 바라보는 경험을 제공하는 공간이다. 자기 성찰과 휴식을 통해 이루어지는 치유를 지향하며, 수목원인 동시에 복합문화공간이기도 하다. <b>궁극적으로 가시림이 구현하고자 하는 것은 “치유의 정원”이다.</b></p>
-      </div>
+      <section class="shop-catalog" aria-label="가시림 상품 목록">
+        <div class="shop-catalog__header">
+          <div class="shop-filters" role="group" aria-label="상품 분류">
+            <button type="button" class="shop-filter is-active">All</button>
+            <button type="button" class="shop-filter">명상</button>
+            <button type="button" class="shop-filter">원예</button>
+            <button type="button" class="shop-filter">차</button>
+          </div>
+          <p class="shop-note">상품을 클릭하면 외부 스토어 페이지가 새 창에서 열립니다.</p>
+        </div>
 
-      <div class="intro-img-wide reveal from-left"></div>
-      <div class="intro-img-tall reveal from-right"></div>
-      <div class="intro-img-long reveal from-up"></div>
+        <div class="shop-grid">
+          <a class="product-card" href="https://example.com/program/meditation" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="정규 명상 수업 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">정규 명상 수업</h3>
+              <p class="product-card__description">매주 화요일·목요일 오전 8시 30분, 숲 속 명상 세션</p>
+              <p class="product-card__price">25,000원</p>
+            </div>
+          </a>
 
-      <div class="article article-container reveal from-up">
-        <h3 class="h left">자연을 다각도에서 체험하다</h3>
-        <p class="p left">가시림은 <b>원예, 명상, 예술</b> 프로그램을 통해 <b>자연을 다각도로 체험</b>할 수 있도록 한다. 이를 통해 자신의 감각과 자연에 집중하고 마음을 편안히 가라앉히며 치유의 시간을 갖게 된다.</p>
-      </div>
+          <a class="product-card" href="https://example.com/program/forest" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/유리온실.jpg" alt="숲 명상 체험 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">숲 명상: 오감으로 느끼는 메타세쿼이아</h3>
+              <p class="product-card__description">숲 해설과 함께하는 90분 명상, 계절별 한정 운영</p>
+              <p class="product-card__price">28,000원</p>
+            </div>
+          </a>
 
-      <div class="intro-mosaic-right reveal from-right"></div>
-      <div class="intro-mosaic-left-top reveal from-left"></div>
-      <div class="intro-mosaic-left-bottom reveal from-left"></div>
-    </section>
+          <a class="product-card" href="https://example.com/program/floral" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/가든센터.jpg" alt="플라워 클래스 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">가드닝 &amp; 플라워 클래스</h3>
+              <p class="product-card__description">정원에서 직접 수확한 소재로 만드는 센터피스 작업</p>
+              <p class="product-card__price">45,000원</p>
+            </div>
+          </a>
+
+          <a class="product-card" href="https://example.com/product/tea" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/카페.jpg" alt="허브 티 세트 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">허브 블렌딩 티 세트</h3>
+              <p class="product-card__description">가시림 온실에서 말린 허브를 블렌딩한 시그니처 티</p>
+              <p class="product-card__price">19,000원</p>
+            </div>
+          </a>
+
+          <a class="product-card" href="https://example.com/program/workshop" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="식물 번식 워크숍 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">식물 번식 워크숍</h3>
+              <p class="product-card__description">삽목과 분주 실습으로 배우는 홈 가드닝 핵심 스킬</p>
+              <p class="product-card__price">32,000원</p>
+            </div>
+          </a>
+
+          <a class="product-card" href="https://example.com/product/mist" target="_blank" rel="noopener noreferrer">
+            <figure class="product-card__media">
+              <img src="assets/img/main.jpg" alt="가시림 시그니처 룸 미스트 상품 이미지" loading="lazy">
+            </figure>
+            <div class="product-card__copy">
+              <h3 class="product-card__title">가시림 시그니처 룸 미스트</h3>
+              <p class="product-card__description">숲 내음과 감귤 향을 담은 공간향, 휴식의 순간을 완성</p>
+              <p class="product-card__price">21,000원</p>
+            </div>
+          </a>
+        </div>
+      </section>
+    </main>
+
+
 
     <!-- Footer (loaded from /partials/footer.html) -->
     <div id="site-footer" data-include="partials/footer.html"></div>

--- a/공간소개.html
+++ b/공간소개.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/단체문의.html
+++ b/단체문의.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/둘러보기.html
+++ b/둘러보기.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/명상.html
+++ b/명상.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/산책명상.html
+++ b/산책명상.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/수목원지도.html
+++ b/수목원지도.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/오시는길.html
+++ b/오시는길.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/원예.html
+++ b/원예.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>

--- a/이용안내.html
+++ b/이용안내.html
@@ -54,6 +54,7 @@
             <div class="gimg gimg-a" role="img" aria-label="갤러리 이미지 A"></div>
             <div class="gimg gimg-b" role="img" aria-label="갤러리 이미지 B"></div>
             <div class="gimg gimg-c" role="img" aria-label="갤러리 이미지 C"></div>
+            <div class="gimg gimg-d" role="img" aria-label="갤러리 이미지 D"></div>
           </div>
         </div>
         <button class="intro-gallery-nav intro-gallery-nav--next" type="button" aria-label="다음 사진" data-gallery-next>


### PR DESCRIPTION
## Summary
- restyle the intro gallery so four images sit side by side on wide screens while keeping the slider experience on small devices
- add a fourth gallery image entry to each marketing page that uses the shared intro gallery markup
- replace the shop body with a catalog-style layout and supporting styles for filters and product cards that link to external pages

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d998d3cc1c83219a66e6b670e73fa4