### PR TITLE
Add modal program details with manual gallery

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1011,6 +1011,523 @@
   gap: clamp(16px, 3vw, 40px) 2%;
 }
 
+/* ===== Program page ===== */
+.program-main {
+  padding: clamp(64px, 11vw, 152px) clamp(20px, 7vw, 120px) clamp(120px, 16vw, 200px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(80px, 12vw, 160px);
+}
+
+.program-hero {
+  display: flex;
+  justify-content: center;
+}
+
+.program-hero__grid {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(28px, 5vw, 64px);
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.program-hero__copy {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2.8vw, 28px);
+}
+
+.program-hero__eyebrow {
+  font-size: 0.875rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: #828282;
+}
+
+.program-hero__title {
+  font-size: clamp(36px, 6vw, 64px);
+  line-height: 1.12;
+  font-weight: 400;
+}
+
+.program-hero__lead {
+  font-size: clamp(18px, 2.6vw, 22px);
+  line-height: 1.6;
+  color: #333333;
+}
+
+.program-hero__description {
+  font-size: clamp(16px, 2.4vw, 18px);
+  line-height: 1.7;
+  color: #666666;
+}
+
+.program-hero__media {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  border-radius: 36px;
+  overflow: hidden;
+  background: #0b2a12;
+  box-shadow: 0 40px 70px rgba(0, 0, 0, 0.16);
+}
+
+.program-hero__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.program-catalog {
+  display: flex;
+  justify-content: center;
+}
+
+.program-grid {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(28px, 5vw, 48px);
+}
+
+.program-card {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 28px 50px rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.program-card__media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #f5f5f5;
+}
+
+.program-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 320ms ease;
+}
+
+.program-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2.4vw, 24px);
+  padding: clamp(24px, 3vw, 36px);
+}
+
+.program-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.program-card__category {
+  font-size: clamp(22px, 3.6vw, 26px);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.program-card__subtitle {
+  font-size: 0.95rem;
+  color: #6f6f6f;
+  line-height: 1.4;
+}
+
+.program-card__description {
+  font-size: clamp(16px, 2.6vw, 18px);
+  line-height: 1.65;
+  color: #4f4f4f;
+}
+
+.program-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  gap: 12px;
+}
+
+.program-card__duration {
+  font-size: 0.95rem;
+  color: #828282;
+}
+
+.program-card__price {
+  font-size: clamp(18px, 2.8vw, 20px);
+  font-weight: 500;
+}
+
+.program-card:is(:hover, :focus-visible) {
+  transform: translateY(-6px);
+  box-shadow: 0 36px 70px rgba(0, 0, 0, 0.16);
+}
+
+.program-card:is(:hover, :focus-visible) .program-card__media img {
+  transform: scale(1.04);
+}
+
+.program-card:focus-visible {
+  outline: 3px solid rgba(27, 94, 55, 0.4);
+  outline-offset: 0;
+}
+
+.program-card:active {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 46px rgba(0, 0, 0, 0.14);
+}
+
+.program-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(40px, 6vh, 80px) clamp(16px, 6vw, 48px);
+}
+
+.program-modal[hidden] {
+  display: none;
+}
+
+.program-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.54);
+  backdrop-filter: blur(3px);
+}
+
+.program-modal__dialog {
+  position: relative;
+  width: min(960px, 100%);
+  max-height: min(880px, calc(100vh - clamp(40px, 6vh, 80px) * 2));
+  background: #fff;
+  border-radius: 36px;
+  overflow: hidden;
+  box-shadow: 0 48px 100px rgba(0, 0, 0, 0.22);
+  display: flex;
+  flex-direction: column;
+}
+
+.program-modal__close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.62);
+  color: #fff;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.program-modal__close:is(:hover, :focus-visible) {
+  background: rgba(0, 0, 0, 0.78);
+  transform: scale(1.04);
+}
+
+.program-modal__content {
+  position: relative;
+  overflow-y: auto;
+  padding: clamp(36px, 5vw, 56px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 6vw, 60px);
+}
+
+.program-modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2.6vw, 24px);
+}
+
+.program-modal__header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
+.program-modal__title {
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.16;
+  font-weight: 400;
+}
+
+.program-modal__subtitle {
+  font-size: clamp(18px, 2.8vw, 20px);
+  line-height: 1.65;
+  color: #4f4f4f;
+}
+
+.program-modal__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 28px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: #111;
+  color: #fff;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease;
+}
+
+.program-modal__cta:is(:hover, :focus-visible) {
+  background: #fff;
+  color: #111;
+  box-shadow: 0 0 0 2px #111 inset;
+  transform: translateY(-1px);
+}
+
+.program-modal__gallery {
+  display: grid;
+  gap: clamp(16px, 2.6vw, 24px);
+}
+
+.program-modal__stage {
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  aspect-ratio: 3 / 2;
+  background: #111;
+}
+
+.program-modal__stage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.program-modal__thumbs {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+}
+
+.program-modal__thumb-track {
+  display: flex;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.program-modal__thumb {
+  flex: 0 0 96px;
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 18px;
+  overflow: hidden;
+  padding: 0;
+  cursor: pointer;
+  background: #f0f0f0;
+  position: relative;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.program-modal__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.program-modal__thumb:is(:hover, :focus-visible) {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.14);
+}
+
+.program-modal__thumb.is-active {
+  box-shadow: 0 0 0 2px #111 inset;
+}
+
+.program-modal__thumb-arrow {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.program-modal__thumb-arrow:is(:hover, :focus-visible) {
+  background: rgba(0, 0, 0, 0.88);
+  transform: scale(1.05);
+}
+
+.program-modal__article {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 3vw, 28px);
+}
+
+.program-modal__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.program-modal__section-title {
+  font-size: clamp(24px, 3.4vw, 30px);
+  font-weight: 500;
+}
+
+.program-modal__paragraph {
+  font-size: 1.05rem;
+  line-height: 1.78;
+  color: #3d3d3d;
+}
+
+.program-modal__facts {
+  display: grid;
+  gap: 14px;
+}
+
+.program-modal__fact {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 12px;
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.program-modal__fact dt {
+  color: #6f6f6f;
+}
+
+.program-modal__list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+  font-size: 0.98rem;
+  line-height: 1.65;
+  color: #3d3d3d;
+}
+
+.program-modal__note {
+  font-size: 0.92rem;
+  color: #828282;
+  line-height: 1.6;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 860px) {
+  .program-modal__dialog {
+    border-radius: 28px;
+  }
+
+  .program-modal__stage {
+    aspect-ratio: 4 / 3;
+  }
+
+  .program-modal__thumb {
+    flex-basis: 80px;
+  }
+
+  .program-modal__facts {
+    gap: 10px;
+  }
+
+  .program-modal__fact {
+    grid-template-columns: 100px minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .program-modal {
+    padding: clamp(28px, 6vh, 48px) clamp(14px, 5vw, 24px);
+  }
+
+  .program-modal__dialog {
+    max-height: calc(100vh - clamp(28px, 6vh, 48px) * 2);
+  }
+
+  .program-modal__content {
+    padding: clamp(28px, 6vw, 40px);
+  }
+
+  .program-modal__header-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .program-modal__thumbs {
+    grid-template-columns: 1fr;
+  }
+
+  .program-modal__thumb-track {
+    order: 1;
+    overflow-x: auto;
+    padding-bottom: 6px;
+  }
+
+  .program-modal__thumb-arrow {
+    order: 0;
+    width: 40px;
+    height: 40px;
+  }
+
+  .program-modal__thumbs {
+    gap: 12px;
+  }
+
+  .program-modal__thumb-track::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .program-modal__thumb-track::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 999px;
+  }
+
+  .program-modal__fact {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 960px) {
+  .program-hero__grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr);
+  }
+
+  .program-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .program-hero__media {
+    aspect-ratio: 3 / 2;
+    border-radius: 28px;
+  }
+
+  .program-card {
+    border-radius: 28px;
+  }
+}
+
 /* ===== Shop page ===== */
 .shop-main {
   padding: clamp(64px, 12vw, 144px) clamp(20px, 7vw, 120px) clamp(120px, 16vw, 200px);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,6 +9,255 @@
     return true;
   }
 
+  const PROGRAM_DATA = {
+    'regular-class': {
+      title: '정규 명상 수업',
+      subtitle: '숲길을 걷고 온실에서 호흡을 정리하며 하루의 호흡을 여는 90분 프로그램.',
+      ctaHref: 'https://forms.gle/7K6YRegularMeditation',
+      ctaLabel: '신청 하기',
+      gallery: [
+        { src: 'assets/img/유리온실2.jpg', alt: '아침 햇살이 드는 온실에서 명상 중인 참가자들' },
+        { src: 'assets/img/유리온실.jpg', alt: '숲길에서 호흡을 맞추며 걷는 정규 명상 수업' },
+        { src: 'assets/img/main.jpg', alt: '햇살이 스며드는 가시림 산책길' },
+        { src: 'assets/img/가든센터.jpg', alt: '온실 앞 휴식 공간에서 허브차를 즐기는 모습' }
+      ],
+      bodyHtml: `
+        <h3 class="program-modal__section-title">프로그램 소개</h3>
+        <p class="program-modal__paragraph">숲의 기운을 몸에 채우는 걷기 명상과 온실에서의 집중 호흡으로 구성된 가시림의 시그니처 정규 수업입니다. 호흡과 몸의 움직임을 섬세하게 정리하여 초심자도 안정적으로 몰입할 수 있도록 구성했습니다.</p>
+        <dl class="program-modal__facts">
+          <div class="program-modal__fact"><dt>진행 요일</dt><dd>매주 화 · 목 08:30 (90분)</dd></div>
+          <div class="program-modal__fact"><dt>장소</dt><dd>가시림 메타세쿼이아 산책길 &amp; 유리온실 명상실</dd></div>
+          <div class="program-modal__fact"><dt>정원</dt><dd>회차당 12명 내외 (선착순 마감)</dd></div>
+          <div class="program-modal__fact"><dt>참가비</dt><dd>25,000원 (허브티 &amp; 온실 입장 포함)</dd></div>
+        </dl>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">커리큘럼</h4>
+          <ol class="program-modal__list">
+            <li>숲길 호흡 워밍업 30분 — 보행 명상과 감각 깨우기</li>
+            <li>온실 프라이빗 스트레칭 20분 — 관절 이완과 중심 잡기</li>
+            <li>앉은 명상 &amp; 바디스캔 25분 — 호흡 리듬에 집중하며 내면 관찰</li>
+            <li>티 세레머니 15분 — 허브차와 함께 일상으로 부드럽게 복귀</li>
+          </ol>
+        </section>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">준비물</h4>
+          <ul class="program-modal__list">
+            <li>움직임이 편한 복장, 가벼운 겉옷</li>
+            <li>개인 물병 (온실 내 정수기 이용 가능)</li>
+            <li>필요 시 개인 요가 매트 (현장 대여 가능)</li>
+          </ul>
+        </section>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">안내 사항</h4>
+          <ul class="program-modal__list">
+            <li>시작 10분 전까지 가든센터 리셉션에서 체크인 해 주세요.</li>
+            <li>지각 시 안전을 위해 다음 회차로 이동될 수 있습니다.</li>
+            <li>우천 시에도 온실 내 프로그램은 정상 진행됩니다.</li>
+          </ul>
+          <p class="program-modal__note">문의: contact@gasirim.kr / 070-4281-0906</p>
+        </section>
+      `
+    },
+    'forest-immersion': {
+      title: '숲 명상: 오감으로 느끼는 메타세쿼이아 숲',
+      subtitle: '계절의 향과 소리를 따라 깊이 몰입하는 주말 집중 명상 여정.',
+      ctaHref: 'https://forms.gle/4V2ForestImmersion',
+      ctaLabel: '신청 하기',
+      gallery: [
+        { src: 'assets/img/유리온실.jpg', alt: '메타세쿼이아 숲길을 천천히 걷는 참가자들' },
+        { src: 'assets/img/main.jpg', alt: '나무 사이로 내리쬐는 햇살과 물안개' },
+        { src: 'assets/img/카페.jpg', alt: '숲 명상 후 티 브레이크를 즐기는 공간' },
+        { src: 'assets/img/가든센터.jpg', alt: '해설가와 함께 숲 식생을 살피는 모습' }
+      ],
+      bodyHtml: `
+        <h3 class="program-modal__section-title">프로그램 소개</h3>
+        <p class="program-modal__paragraph">울창한 메타세쿼이아 숲을 가이드와 함께 천천히 걷고, 향과 소리를 세밀하게 탐색하며 감각을 열어가는 주말 집중 프로그램입니다. 계절에 따라 달라지는 숲의 스토리를 담은 해설과 함께 깊은 몰입을 경험해 보세요.</p>
+        <dl class="program-modal__facts">
+          <div class="program-modal__fact"><dt>진행 요일</dt><dd>계절별 주말 10:00 (120분)</dd></div>
+          <div class="program-modal__fact"><dt>장소</dt><dd>가시림 메타세쿼이아 숲길 &amp; 야외 명상존</dd></div>
+          <div class="program-modal__fact"><dt>정원</dt><dd>회차당 16명 (사전 예약 필수)</dd></div>
+          <div class="program-modal__fact"><dt>참가비</dt><dd>25,000원 (숲 해설 &amp; 허브 블렌딩 포함)</dd></div>
+        </dl>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">커리큘럼</h4>
+          <ol class="program-modal__list">
+            <li>사운드 어웨어니스 25분 — 새소리와 바람을 듣는 호흡 정렬</li>
+            <li>포커스 워크 35분 — 식생 해설과 함께 감각 확장</li>
+            <li>야외 바디스캔 30분 — 자연물과 함께하는 촉각 명상</li>
+            <li>향 테라피 &amp; 쉐어링 30분 — 계절 허브 블렌딩과 나눔</li>
+          </ol>
+        </section>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">준비물</h4>
+          <ul class="program-modal__list">
+            <li>편안한 운동화 및 우천 대비 우비</li>
+            <li>개인 방석 또는 접이식 시트 (현장 대여 가능)</li>
+            <li>모기 기피제, 개인 보온 음료</li>
+          </ul>
+        </section>
+        <section class="program-modal__section">
+          <h4 class="program-modal__section-title">안내 사항</h4>
+          <ul class="program-modal__list">
+            <li>기상 상황에 따라 일부 코스는 숲 해설 데크로 대체될 수 있습니다.</li>
+            <li>자연 보호를 위해 개인 쓰레기는 반드시 되가져가 주세요.</li>
+            <li>10세 이하 아동은 보호자 동반 시 참여 가능합니다.</li>
+          </ul>
+          <p class="program-modal__note">문의: programs@gasirim.kr / 070-4281-0906</p>
+        </section>
+      `
+    }
+  };
+
+  function initProgramModals() {
+    const modal = document.querySelector('[data-program-modal]');
+    const cards = document.querySelectorAll('[data-program-id]');
+    if (!modal || !cards.length || !markOnce(modal, 'programModalBound')) return;
+
+    const dialog = modal.querySelector('.program-modal__dialog');
+    const content = modal.querySelector('[data-program-modal-content]');
+    const closeEls = modal.querySelectorAll('[data-program-modal-close]');
+    let activeTrigger = null;
+
+    const updateGallery = (galleryRoot, images) => {
+      const stageImg = galleryRoot.querySelector('[data-program-modal-stage]');
+      const thumbButtons = Array.from(galleryRoot.querySelectorAll('.program-modal__thumb'));
+      const prev = galleryRoot.querySelector('[data-program-modal-prev]');
+      const next = galleryRoot.querySelector('[data-program-modal-next]');
+      let activeIndex = 0;
+
+      const setActive = (index) => {
+        if (!images[index]) return;
+        activeIndex = index;
+        stageImg.src = images[index].src;
+        stageImg.alt = images[index].alt;
+        thumbButtons.forEach((btn, idx) => {
+          btn.classList.toggle('is-active', idx === index);
+          if (idx === index) {
+            btn.setAttribute('aria-current', 'true');
+            btn.scrollIntoView({ block: 'nearest', inline: 'center', behavior: 'smooth' });
+          } else {
+            btn.removeAttribute('aria-current');
+          }
+        });
+      };
+
+      thumbButtons.forEach((btn, idx) => {
+        btn.addEventListener('click', () => setActive(idx));
+      });
+
+      prev?.addEventListener('click', () => {
+        const nextIndex = (activeIndex - 1 + images.length) % images.length;
+        setActive(nextIndex);
+      });
+
+      next?.addEventListener('click', () => {
+        const nextIndex = (activeIndex + 1) % images.length;
+        setActive(nextIndex);
+      });
+
+      setActive(0);
+    };
+
+    const renderModal = (id) => {
+      const data = PROGRAM_DATA[id];
+      if (!data) return false;
+      content.innerHTML = '';
+
+      const header = document.createElement('header');
+      header.className = 'program-modal__header';
+      header.innerHTML = `
+        <div class="program-modal__header-top">
+          <h2 class="program-modal__title" id="program-modal-title">${data.title}</h2>
+          <a class="program-modal__cta" href="${data.ctaHref}" target="_blank" rel="noopener noreferrer">${data.ctaLabel}</a>
+        </div>
+        <p class="program-modal__subtitle">${data.subtitle}</p>
+      `;
+      content.appendChild(header);
+
+      if (Array.isArray(data.gallery) && data.gallery.length) {
+        const gallery = document.createElement('section');
+        gallery.className = 'program-modal__gallery';
+        gallery.setAttribute('aria-label', '프로그램 이미지 갤러리');
+        gallery.innerHTML = `
+          <figure class="program-modal__stage">
+            <img src="${data.gallery[0].src}" alt="${data.gallery[0].alt}" data-program-modal-stage>
+          </figure>
+          <div class="program-modal__thumbs">
+            <button type="button" class="program-modal__thumb-arrow" data-program-modal-prev aria-label="이전 이미지">&#8592;</button>
+            <div class="program-modal__thumb-track" data-program-modal-track>
+              ${data.gallery.map((image, index) => `
+                <button type="button" class="program-modal__thumb${index === 0 ? ' is-active' : ''}" data-index="${index}">
+                  <img src="${image.src}" alt="${image.alt}">
+                </button>
+              `).join('')}
+            </div>
+            <button type="button" class="program-modal__thumb-arrow" data-program-modal-next aria-label="다음 이미지">&#8594;</button>
+          </div>
+        `;
+        content.appendChild(gallery);
+        updateGallery(gallery, data.gallery);
+      }
+
+      const article = document.createElement('article');
+      article.className = 'program-modal__article';
+      article.innerHTML = data.bodyHtml;
+      content.appendChild(article);
+
+      content.scrollTop = 0;
+      return true;
+    };
+
+    const closeModal = () => {
+      if (modal.hasAttribute('hidden')) return;
+      modal.setAttribute('hidden', '');
+      modal.classList.remove('is-open');
+      document.body.classList.remove('modal-open');
+      content.innerHTML = '';
+      if (activeTrigger) {
+        activeTrigger.focus();
+        activeTrigger = null;
+      }
+    };
+
+    const openModal = (id, trigger) => {
+      if (!renderModal(id)) return;
+      activeTrigger = trigger || null;
+      modal.classList.add('is-open');
+      modal.removeAttribute('hidden');
+      document.body.classList.add('modal-open');
+      if (dialog) {
+        dialog.scrollTop = 0;
+      }
+      dialog?.focus({ preventScroll: true });
+    };
+
+    closeEls.forEach((el) => {
+      el.addEventListener('click', closeModal);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hasAttribute('hidden')) {
+        event.preventDefault();
+        closeModal();
+      }
+    });
+
+    cards.forEach((card) => {
+      card.addEventListener('click', () => {
+        const id = card.dataset.programId;
+        openModal(id, card);
+      });
+
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          const id = card.dataset.programId;
+          openModal(id, card);
+        }
+      });
+    });
+  }
+
   // ---------- Reveal on scroll ----------
   function initReveal() {
     const root = document.documentElement;
@@ -439,6 +688,7 @@
     initHeaderScroll();
     initHeroCarousel();
     initIntroGalleries();
+    initProgramModals();
   }
 
   document.addEventListener('DOMContentLoaded', initAll);

--- a/program.html
+++ b/program.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Programs | 가시림</title>
+  <meta name="description" content="가시림 명상 프로그램 — 숲과 원예, 감각을 깨우는 명상 수업 안내." />
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+
+  <!-- Preload the big header background (faster perceived load) -->
+  <link rel="preload" as="image" href="assets/img/main.jpg">
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=Zen+Old+Mincho&family=Nanum+Myeongjo&display=swap"/>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="assets/css/styleguide.css"/>
+  <link rel="stylesheet" href="assets/css/globals.css"/>
+  <link rel="stylesheet" href="assets/css/style.css"/>
+</head>
+<body>
+  <div class="page">
+    <!-- Header -->
+    <div id="site-header" data-include="partials/header-site.html"></div>
+
+    <main class="program-main" aria-labelledby="program-heading">
+      <section class="program-hero">
+        <div class="program-hero__grid">
+          <div class="program-hero__copy">
+            <p class="program-hero__eyebrow">Programs</p>
+            <h1 class="program-hero__title" id="program-heading">가시림 명상 프로그램</h1>
+            <p class="program-hero__lead">숲의 호흡을 닮은 루틴과 명상, 가드닝이 어우러진 가시림의 시그니처 프로그램을 소개합니다. 호흡을 따라 걷고, 계절의 향을 음미하며 자신과 마주하는 시간을 준비했습니다.</p>
+            <p class="program-hero__description">Interpret different emerging, even when venian anim aute carefully. Evocative Garden awesomely restorative practices mindful and intrinsic. Compose, slow intentional forest-bath rituals. Punctual alongside, essential inquiry eleven tempor ensured true.</p>
+          </div>
+          <figure class="program-hero__media">
+            <img src="assets/img/main.jpg" alt="나무 사이로 들어오는 햇살이 비추는 숲길" loading="lazy">
+          </figure>
+        </div>
+      </section>
+
+      <section class="program-catalog" aria-label="가시림 명상 프로그램 목록">
+        <div class="program-grid">
+          <article class="program-card" role="button" tabindex="0" aria-haspopup="dialog" data-program-id="regular-class">
+            <figure class="program-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="정규 명상 수업 장면" loading="lazy">
+            </figure>
+            <div class="program-card__body">
+              <div class="program-card__meta">
+                <p class="program-card__category">정규 명상 수업</p>
+                <p class="program-card__subtitle">매주 화·목 08:30 — 숲길 호흡과 온실 명상</p>
+              </div>
+              <p class="program-card__description">여명의 빛이 드는 산책길을 따라 몸을 깨우고, 온실에서의 집중 호흡으로 하루를 단단하게 여는 정규 세션입니다. 초심자도 안전하게 따라올 수 있도록 호흡의 리듬과 마음챙김을 세심하게 안내합니다.</p>
+              <div class="program-card__footer">
+                <p class="program-card__duration">90분 프로그램</p>
+                <p class="program-card__price">25,000원</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="program-card" role="button" tabindex="0" aria-haspopup="dialog" data-program-id="forest-immersion">
+            <figure class="program-card__media">
+              <img src="assets/img/유리온실.jpg" alt="메타세쿼이아 숲 명상" loading="lazy">
+            </figure>
+            <div class="program-card__body">
+              <div class="program-card__meta">
+                <p class="program-card__category">숲 명상: 오감으로 느끼는 메타세쿼이아 숲</p>
+                <p class="program-card__subtitle">계절별 주말 10:00 — 숲 해설과 함께하는 깊은 몰입</p>
+              </div>
+              <p class="program-card__description">울창한 메타세쿼이아 숲에서 계절별 향과 색을 느끼며 감각을 열고, 자연의 소리를 오롯이 듣는 시간을 마련했습니다. 안내자의 세심한 해설과 함께 숲의 숨결에 집중하는 깊은 명상 여정을 경험해보세요.</p>
+              <div class="program-card__footer">
+                <p class="program-card__duration">120분 프로그램</p>
+                <p class="program-card__price">25,000원</p>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <div class="program-modal" data-program-modal hidden>
+      <div class="program-modal__backdrop" data-program-modal-close></div>
+      <div class="program-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="program-modal-title" tabindex="-1">
+        <button type="button" class="program-modal__close" aria-label="닫기" data-program-modal-close>
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <div class="program-modal__content" data-program-modal-content></div>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div id="site-footer" data-include="partials/footer.html"></div>
+  </div>
+
+  <!-- JS -->
+  <script src="assets/js/includes.js" defer></script>
+  <script src="https://unpkg.com/embla-carousel/embla-carousel.umd.js" defer></script>
+  <script src="https://unpkg.com/embla-carousel-autoplay/embla-carousel-autoplay.umd.js" defer></script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make each program card accessible and clickable to open a dedicated detail modal
- implement modal layout with CTA, detailed copy, and manual thumbnail gallery for program images
- extend shared styles and scripts to support modal presentation, keyboard access, and gallery controls

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd03a90fe483218bc83ccf9d9b9790