### PR TITLE
Revamp gallery, program, and visit pages

### DIFF
--- a/assets/css/globals.css
+++ b/assets/css/globals.css
@@ -5,7 +5,6 @@ html, body {
   height: 100%;
   background: var(--color-bg);
   color: var(--color-text);
-  /*font-family: var(--font-sans);*/
 }
 
 /* Utility: screen-reader only */
@@ -50,3 +49,20 @@ html { scroll-behavior: smooth; }
 
 /* Optional: unify link coloring with text (you style links locally) */
 a { color: inherit; text-decoration: none;}
+
+/* Headings share the sans-serif system stack */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  font-size: clamp(3rem, 5vw, 3.5rem);
+  line-height: 1.2;
+}
+
+:root {
+  --page-pad: clamp(20px, 5vw, 72px);
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -298,24 +298,37 @@
 }
 
 .embla__copy {
-  max-width: 58ch;
+  max-width: 42ch;
 }
 
 .embla__copy h1 {
-  margin-bottom: .25rem;
-  font-size: 2.5rem;
-  font-weight: 400;
-  line-height: 1.25;
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 5rem);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  animation: emblaHeadline 1400ms ease both;
 }
 
-.embla__copy p {
-  font-size: .875rem;
-  line-height: 1.4;
-  margin: 0;
+.embla__copy h1 span {
+  display: inline-block;
+  font-weight: 500;
 }
 
 .text-variable {
   color: hsla(40,20%,56.2%,1);
+}
+
+@keyframes emblaHeadline {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 40px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 .embla__asset-text {
@@ -992,8 +1005,6 @@
   min-height: 58px;
   margin: 0 auto;
   font-weight: 300;
-  font-size: clamp(28px, 4.2vw, 48px);
-  line-height: 1.2;
   letter-spacing: -0.02em;
   color: #000;
   text-align: center;
@@ -1013,19 +1024,37 @@
 
 /* ===== Program page ===== */
 .program-main {
-  padding: clamp(64px, 11vw, 152px) clamp(20px, 7vw, 120px) clamp(120px, 16vw, 200px);
+  padding: clamp(96px, 14vw, 180px) var(--page-pad) clamp(140px, 18vw, 220px);
   display: flex;
   flex-direction: column;
   gap: clamp(80px, 12vw, 160px);
 }
 
 .program-hero {
-  display: flex;
-  justify-content: center;
+  position: relative;
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(48px, 6vw, 72px);
+  border-radius: 44px;
+  background:
+    radial-gradient(120% 140% at 10% 10%, rgba(134, 190, 156, 0.35), transparent 60%),
+    radial-gradient(120% 140% at 90% 0%, rgba(214, 236, 221, 0.28), transparent 70%),
+    linear-gradient(135deg, #102f23 0%, #184430 55%, #205541 100%);
+  color: rgba(245, 247, 244, 0.96);
+  overflow: hidden;
+}
+
+.program-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 100% at 50% 80%, rgba(255, 255, 255, 0.12), transparent 70%);
+  pointer-events: none;
 }
 
 .program-hero__grid {
-  width: min(1100px, 100%);
+  position: relative;
+  z-index: 1;
   display: grid;
   gap: clamp(28px, 5vw, 64px);
   align-items: center;
@@ -1039,28 +1068,26 @@
 }
 
 .program-hero__eyebrow {
-  font-size: 0.875rem;
-  letter-spacing: 0.26em;
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: #828282;
+  color: rgba(216, 238, 222, 0.7);
 }
 
-.program-hero__title {
-  font-size: clamp(36px, 6vw, 64px);
-  line-height: 1.12;
-  font-weight: 400;
+.program-hero__lead,
+.program-hero__description {
+  color: rgba(240, 246, 242, 0.82);
 }
 
 .program-hero__lead {
-  font-size: clamp(18px, 2.6vw, 22px);
-  line-height: 1.6;
-  color: #333333;
+  font-size: 1.1rem;
+  line-height: 1.7;
 }
 
 .program-hero__description {
-  font-size: clamp(16px, 2.4vw, 18px);
-  line-height: 1.7;
-  color: #666666;
+  font-size: 1rem;
+  line-height: 1.8;
+  max-width: 60ch;
 }
 
 .program-hero__media {
@@ -1068,14 +1095,100 @@
   aspect-ratio: 3 / 4;
   border-radius: 36px;
   overflow: hidden;
-  background: #0b2a12;
-  box-shadow: 0 40px 70px rgba(0, 0, 0, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 44px 90px rgba(0, 0, 0, 0.26);
+}
+
+.program-hero__media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
+  mix-blend-mode: multiply;
 }
 
 .program-hero__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transform: scale(1.02);
+}
+
+.program-summary {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 36px);
+}
+
+.program-summary__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #1f1f1f;
+}
+
+.program-summary__intro {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(0, 0, 0, 0.68);
+  max-width: 60ch;
+}
+
+.program-summary__grid {
+  display: grid;
+  gap: clamp(20px, 3vw, 32px);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.program-summary__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(24px, 4vw, 32px);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(240, 243, 238, 0.92), #fff);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.program-summary__card:is(:hover, :focus-visible) {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.12);
+}
+
+.program-summary__badge {
+  font-size: 0.8rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.46);
+}
+
+.program-summary__excerpt {
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.program-summary__cta {
+  margin-top: auto;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #205541;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.program-summary__cta::after {
+  content: "→";
+  font-size: 1rem;
 }
 
 .program-catalog {
@@ -1222,9 +1335,9 @@
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  border: none;
-  background: rgba(0, 0, 0, 0.62);
-  color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.94);
+  color: #111;
   font-size: 28px;
   line-height: 1;
   cursor: pointer;
@@ -1235,14 +1348,15 @@
 }
 
 .program-modal__close:is(:hover, :focus-visible) {
-  background: rgba(0, 0, 0, 0.78);
+  background: #111;
+  color: #fff;
   transform: scale(1.04);
 }
 
 .program-modal__content {
   position: relative;
   overflow-y: auto;
-  padding: clamp(36px, 5vw, 56px);
+  padding: clamp(52px, 7vw, 68px);
   display: flex;
   flex-direction: column;
   gap: clamp(32px, 6vw, 60px);
@@ -1262,8 +1376,6 @@
 }
 
 .program-modal__title {
-  font-size: clamp(32px, 4vw, 48px);
-  line-height: 1.16;
   font-weight: 400;
 }
 
@@ -1277,13 +1389,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 28px;
+  padding: 12px 32px;
   border-radius: 999px;
   border: 1px solid transparent;
   background: #111;
   color: #fff;
   font-size: 0.95rem;
   text-decoration: none;
+  white-space: nowrap;
   transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease;
 }
 
@@ -1386,7 +1499,6 @@
 }
 
 .program-modal__section-title {
-  font-size: clamp(24px, 3.4vw, 30px);
   font-weight: 500;
 }
 
@@ -1398,7 +1510,10 @@
 
 .program-modal__facts {
   display: grid;
-  gap: 14px;
+  gap: 16px;
+  background: #f4f6f3;
+  border-radius: 22px;
+  padding: 24px 28px;
 }
 
 .program-modal__fact {
@@ -1411,6 +1526,27 @@
 
 .program-modal__fact dt {
   color: #6f6f6f;
+}
+
+.program-modal__notice {
+  margin-top: clamp(12px, 2vw, 20px);
+  padding: 24px 28px;
+  border-radius: 22px;
+  background: #eff1ee;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.program-modal__notice .program-modal__list {
+  color: rgba(33, 33, 33, 0.82);
+}
+
+.program-modal__notice .program-modal__note {
+  color: rgba(32, 85, 65, 0.9);
+  font-weight: 500;
 }
 
 .program-modal__list {
@@ -1534,23 +1670,36 @@ body.modal-open {
   .program-card {
     border-radius: 28px;
   }
+
+  .program-modal__facts {
+    padding: 20px;
+  }
+
+  .program-modal__fact {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ===== Shop page ===== */
 .shop-main {
-  padding: clamp(64px, 12vw, 144px) clamp(20px, 7vw, 120px) clamp(120px, 16vw, 200px);
+  padding: clamp(96px, 14vw, 180px) var(--page-pad) clamp(140px, 18vw, 220px);
   display: flex;
   flex-direction: column;
   gap: clamp(72px, 12vw, 160px);
 }
 
+.shop-main > * {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+}
+
 .shop-overview {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .shop-overview__inner {
-  width: min(720px, 100%);
+  width: min(760px, 100%);
   display: flex;
   flex-direction: column;
   gap: clamp(16px, 3vw, 28px);
@@ -1564,8 +1713,6 @@ body.modal-open {
 }
 
 .shop-overview__title {
-  font-size: clamp(32px, 5vw, 56px);
-  line-height: 1.12;
   font-weight: 400;
 }
 
@@ -1623,8 +1770,14 @@ body.modal-open {
 
 .shop-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: clamp(28px, 5vw, 48px);
+}
+
+@media (min-width: 1024px) {
+  .shop-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .product-card {
@@ -1658,9 +1811,8 @@ body.modal-open {
 }
 
 .product-card__title {
-  font-size: clamp(22px, 3.4vw, 26px);
   font-weight: 500;
-  line-height: 1.4;
+  line-height: 1.3;
 }
 
 .product-card__description {
@@ -1740,33 +1892,6 @@ body.modal-open {
   transition: transform 500ms cubic-bezier(.2,.7,.2,1), filter 500ms ease;
 }
 
-/* ===== for 공간 소개 page ===== */
-.space-card {
-  width: 624px;
-  height: 409px;
-  overflow: hidden;
-  border-radius: var(--radius-lg);
-  transition: transform 400ms cubic-bezier(.2,.7,.2,1), box-shadow 400ms ease;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 32px;
-  position: relative;
-}
-
-.space-card-img {
-  width: 100%;
-  height: 341px;
-  object-fit: cover;
-  transition: transform 500ms cubic-bezier(.2,.7,.2,1), filter 500ms ease;
-}
-
-.space-card-title {
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 150%;
-}
-
 .card-overlay {
   position: absolute;
   inset: 0;
@@ -1776,9 +1901,10 @@ body.modal-open {
 
 .card-label {
   position: absolute;
-  left: 50%; top: 50%;
+  left: 50%;
+  top: 50%;
   transform: translate(-50%, -40%);
-  color: #FFF;
+  color: #fff;
   font-weight: 400;
   font-size: clamp(28px, 4.2vw, 48px);
   letter-spacing: -0.02em;
@@ -1792,6 +1918,72 @@ body.modal-open {
 .card:hover .card-overlay { background: linear-gradient(180deg, rgba(0,0,0,.5) 0%, rgba(0,0,0,.3) 50%, rgba(0,0,0,.15) 100%); }
 .card:hover .card-label   { transform: translate(-50%, -50%); opacity: 1; }
 .card:focus-visible        { outline: 3px solid #222; outline-offset: 3px; }
+
+/* ===== 공간 소개 ===== */
+.space-filters {
+  justify-content: center;
+  margin-bottom: clamp(32px, 6vw, 48px);
+}
+
+.space-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(24px, 4vw, 40px);
+}
+
+.space-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 22px 60px rgba(0,0,0,0.10);
+  transition: transform 300ms ease, box-shadow 300ms ease;
+}
+
+.space-card.is-hidden {
+  display: none;
+}
+
+.space-card__media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.space-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 400ms ease;
+}
+
+.space-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 24px 28px;
+}
+
+.space-card__title {
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+.space-card__summary {
+  font-size: 1rem;
+  color: rgba(17, 17, 17, 0.7);
+  line-height: 1.6;
+}
+
+.space-card:is(:hover, :focus-within) {
+  transform: translateY(-8px);
+  box-shadow: 0 28px 68px rgba(0,0,0,0.14);
+}
+
+.space-card:is(:hover, :focus-within) .space-card__media img {
+  transform: scale(1.05);
+}
 
 /* ===== Footer ===== */
 .site-footer {
@@ -1818,22 +2010,31 @@ body.modal-open {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-top: 48px; /* align with columns */
+  margin-top: 48px;
 }
 
 .footer-logo {
-  width: 119px;
-  height: 38px;
+  width: 160px;
+  height: auto;
   object-fit: contain;
-  margin-right: 12px; /* right-only spacing */
+  margin-right: 12px;
   margin-bottom: 12px;
 }
 
 .footer-contact {
-  font: 300 12px/15px Inter, sans-serif;
-  color: #000;
-  margin-right: 12px; /* right-only spacing */
-  margin-bottom: 12px;
+  font: 400 0.9rem/1.6 var(--font-sans);
+  color: #111;
+  margin-right: 12px;
+  margin-bottom: 16px;
+}
+
+.footer-contact__item {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.footer-contact__item:last-child {
+  margin-bottom: 0;
 }
 .footer-contact a { color: inherit; text-decoration: none; }
 .footer-contact a:hover { text-decoration: underline; }
@@ -1847,16 +2048,18 @@ body.modal-open {
 }
 
 .social-btn {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-sm);
-  color: #828282;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.08);
+  color: #111;
   text-decoration: none;
+  transition: transform 160ms ease, background 160ms ease;
 }
-.social-btn:hover { color: #000; }
+.social-btn:hover { background: rgba(0,0,0,0.18); transform: translateY(-2px); }
 .social-btn:focus-visible {
   outline: 2px solid #222;
   outline-offset: 2px;
@@ -1992,39 +2195,64 @@ body.modal-open {
   align-items: center;
   background: rgba(0,0,0,.8);
   z-index: 3000;
+  padding: clamp(24px, 6vh, 48px);
+  overflow-y: auto;
 }
 
 .space-modal-content {
   position: relative;
   background: #fff;
   color: #111;
-  max-width: 800px;
-  width: 90%;
+  max-width: 960px;
+  width: min(960px, 92%);
   max-height: 90vh;
-  padding: 1.5rem;
-  border-radius: var(--radius-lg);
-  overflow: auto;
+  padding: 2.5rem 2.75rem 3rem;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 40px 80px rgba(0,0,0,0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  overflow-y: auto;
 }
 
 .space-modal-close {
   position: absolute;
-  top: .5rem;
-  right: .5rem;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 48px;
+  height: 48px;
+  border: 1px solid rgba(0,0,0,0.15);
+  border-radius: 50%;
+  background: rgba(255,255,255,0.9);
+  color: #111;
+  display: grid;
+  place-items: center;
+  font-size: 1.75rem;
+  line-height: 1;
   cursor: pointer;
+  transition: transform 200ms ease, border-color 200ms ease, background 200ms ease;
+}
+
+.space-modal-close:is(:hover, :focus-visible) {
+  transform: scale(1.05);
+  border-color: #111;
+  background: #111;
+  color: #fff;
 }
 
 .space-modal-embla {
   width: 100%;
-  height: 300px;
-  margin-bottom: 1rem;
+  height: min(420px, 50vh);
+}
+
+.space-modal-content > *:not(.space-modal-close) {
+  position: relative;
 }
 
 .space-modal-embla .embla__viewport {
   height: 100%;
-  border-radius: var(--radius-lg);
+  border-radius: 22px;
 }
 
 .space-modal-embla .embla__slide img {
@@ -2035,7 +2263,7 @@ body.modal-open {
 
 .space-modal-embla .embla__controls {
   justify-content: center;
-  margin-top: .5rem;
+  margin-top: .75rem;
 }
 
 .space-modal-embla .embla__prev,
@@ -2045,10 +2273,289 @@ body.modal-open {
 }
 
 .space-modal-title {
-  margin: 0 0 .5rem;
-  font-size: 1.5rem;
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
 }
 
 .space-modal-desc {
   margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(0,0,0,0.72);
+}
+/* ===== Visit page ===== */
+.visit-main {
+  padding: clamp(96px, 14vw, 180px) var(--page-pad) clamp(140px, 18vw, 220px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(80px, 12vw, 160px);
+  background: #f8f7f3;
+}
+
+.visit-hero {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(40px, 6vw, 64px);
+  border-radius: 40px;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(184, 210, 194, 0.22), transparent 60%),
+    radial-gradient(110% 130% at 100% 0%, rgba(226, 236, 229, 0.28), transparent 70%),
+    #ffffff;
+  box-shadow: 0 32px 70px rgba(18, 44, 32, 0.12);
+}
+
+.visit-hero__copy {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+  color: #10271b;
+}
+
+.visit-hero__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(16, 39, 27, 0.55);
+}
+
+.visit-hero__lead {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: rgba(16, 39, 27, 0.7);
+  max-width: 60ch;
+}
+
+.visit-hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.visit-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  background: rgba(32, 85, 65, 0.12);
+  color: #205541;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: transform 200ms ease, background 200ms ease;
+}
+
+.visit-chip:is(:hover, :focus-visible) {
+  transform: translateY(-3px);
+  background: rgba(32, 85, 65, 0.18);
+}
+
+.visit-section {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(36px, 6vw, 56px);
+  border-radius: 36px;
+  background: #ffffff;
+  box-shadow: 0 32px 70px rgba(18, 44, 32, 0.12);
+  display: grid;
+  gap: clamp(32px, 5vw, 48px);
+}
+
+.visit-section__header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 640px;
+}
+
+.visit-section__label {
+  font-size: 0.82rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(16, 39, 27, 0.45);
+}
+
+.visit-section__lead {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: rgba(16, 39, 27, 0.62);
+}
+
+.visit-grid {
+  display: grid;
+  gap: clamp(20px, 3vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.visit-card {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(24px, 4vw, 32px);
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(244, 248, 245, 0.92), #fff);
+  border: 1px solid rgba(32, 85, 65, 0.12);
+  box-shadow: 0 24px 60px rgba(18, 44, 32, 0.08);
+}
+
+.visit-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(32, 85, 65, 0.12);
+  color: #205541;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.visit-card__title {
+  font-weight: 600;
+  font-size: 1.2rem;
+  color: #10271b;
+}
+
+.visit-card p,
+.visit-card li {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: rgba(16, 39, 27, 0.68);
+}
+
+.visit-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.visit-card ul li::before {
+  content: "•";
+  color: #205541;
+  margin-right: 0.6rem;
+  font-weight: 700;
+}
+
+.visit-card ul li {
+  display: flex;
+  align-items: flex-start;
+}
+
+.visit-map {
+  position: relative;
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 32px 70px rgba(18, 44, 32, 0.14);
+  border: 1px solid rgba(32, 85, 65, 0.12);
+  min-height: 320px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.visit-map iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.visit-map__badge {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(16, 29, 22, 0.85);
+  color: #f2f2ed;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.visit-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.visit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.5rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease;
+}
+
+.visit-button--primary {
+  background: #205541;
+  color: #f5f7f4;
+  box-shadow: 0 20px 48px rgba(32, 85, 65, 0.25);
+}
+
+.visit-button--primary:is(:hover, :focus-visible) {
+  transform: translateY(-3px);
+  background: #174232;
+}
+
+.visit-button--ghost {
+  border: 1px solid rgba(32, 85, 65, 0.24);
+  color: #205541;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.visit-button--ghost:is(:hover, :focus-visible) {
+  transform: translateY(-3px);
+  background: #ffffff;
+  border-color: rgba(32, 85, 65, 0.4);
+}
+
+.contact-grid {
+  display: grid;
+  gap: clamp(20px, 3vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.contact-card {
+  padding: clamp(22px, 3.5vw, 28px);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(244, 248, 245, 0.92), #fff);
+  border: 1px solid rgba(32, 85, 65, 0.12);
+  box-shadow: 0 20px 50px rgba(18, 44, 32, 0.12);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.contact-card span {
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(16, 39, 27, 0.45);
+  font-weight: 600;
+}
+
+.contact-card a {
+  color: #205541;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.contact-card a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  .visit-section {
+    padding: clamp(28px, 8vw, 40px);
+  }
+
+  .visit-map__badge {
+    position: static;
+    margin: 16px;
+    display: inline-flex;
+  }
 }

--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -1,5 +1,5 @@
 :root {
-  --page-pad: clamp(16px, 4vw, 40px);
+  --page-pad: clamp(20px, 5vw, 72px);
   --section-gap: clamp(24px, 6vw, 64px);
   /* Colors */
   --color-bg: #ffffff;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,7 +14,7 @@
       title: '새벽 산책 명상',
       subtitle: '숲의 첫 공기를 마시며 리듬을 깨우는 75분 보행 명상.',
       ctaHref: 'https://forms.gle/2SunriseWalk',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/main.jpg', alt: '새벽 햇살이 비치는 가시림 숲길' },
         { src: 'assets/img/유리온실.jpg', alt: '숲 해설가와 함께 걷는 참가자들' },
@@ -47,7 +47,7 @@
             <li>필요 시 가벼운 장갑</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>일출 시각에 따라 시작 시간이 10분 내외로 조정될 수 있습니다.</li>
@@ -55,14 +55,14 @@
             <li>노약자는 스태프의 별도 안내에 따라 진행합니다.</li>
           </ul>
           <p class="program-modal__note">문의: walk@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     },
     'forest-immersion': {
       title: '숲 명상: 오감으로 느끼는 메타세쿼이아 숲',
       subtitle: '계절의 향과 소리를 따라 깊이 몰입하는 주말 집중 명상 여정.',
       ctaHref: 'https://forms.gle/4V2ForestImmersion',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/유리온실.jpg', alt: '메타세쿼이아 숲길을 천천히 걷는 참가자들' },
         { src: 'assets/img/main.jpg', alt: '나무 사이로 내리쬐는 햇살과 물안개' },
@@ -95,7 +95,7 @@
             <li>모기 기피제, 개인 보온 음료</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>기상 상황에 따라 일부 코스는 숲 해설 데크로 대체될 수 있습니다.</li>
@@ -103,14 +103,14 @@
             <li>10세 이하 아동은 보호자 동반 시 참여 가능합니다.</li>
           </ul>
           <p class="program-modal__note">문의: programs@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     },
     'regular-class': {
       title: '정규 명상 수업',
       subtitle: '숲길을 걷고 온실에서 호흡을 정리하며 하루의 호흡을 여는 90분 프로그램.',
       ctaHref: 'https://forms.gle/7K6YRegularMeditation',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/유리온실2.jpg', alt: '아침 햇살이 드는 온실에서 명상 중인 참가자들' },
         { src: 'assets/img/유리온실.jpg', alt: '숲길에서 호흡을 맞추며 걷는 정규 명상 수업' },
@@ -143,7 +143,7 @@
             <li>필요 시 개인 요가 매트 (현장 대여 가능)</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>시작 10분 전까지 가든센터 리셉션에서 체크인 해 주세요.</li>
@@ -151,14 +151,14 @@
             <li>우천 시에도 온실 내 프로그램은 정상 진행됩니다.</li>
           </ul>
           <p class="program-modal__note">문의: contact@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     },
     'deep-rest': {
       title: '사운드 배스 명상: 딥레스트 세션',
       subtitle: '촛불과 싱잉볼 사운드로 몸과 마음을 깊이 이완하는 야간 명상.',
       ctaHref: 'https://forms.gle/6DeepRestSound',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/카페.jpg', alt: '촛불이 켜진 명상 공간' },
         { src: 'assets/img/유리온실2.jpg', alt: '온실 내부의 조용한 명상 공간' },
@@ -191,7 +191,7 @@
             <li>물병 또는 따뜻한 차</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>프로그램 시작 15분 전까지 전자기기를 보관함에 보관해 주세요.</li>
@@ -199,14 +199,14 @@
             <li>특정 사운드에 민감하다면 사전 문의 부탁드립니다.</li>
           </ul>
           <p class="program-modal__note">문의: meditation@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     },
     'horticulture-lab': {
       title: '감각원예 워크숍',
       subtitle: '계절 식물을 손끝으로 돌보며 식물 케어 루틴을 배우는 가드닝 클래스.',
       ctaHref: 'https://forms.gle/3HortiLab',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/가든센터.jpg', alt: '분갈이 도구와 식물을 준비하는 모습' },
         { src: 'assets/img/유리온실2.jpg', alt: '온실에서 식물을 살피는 참가자' },
@@ -239,7 +239,7 @@
             <li>필요 시 개인 장갑</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>재료 준비를 위해 예약은 최소 2일 전까지 완료해 주세요.</li>
@@ -247,14 +247,14 @@
             <li>완성 작품은 안전 포장 후 가져가실 수 있습니다.</li>
           </ul>
           <p class="program-modal__note">문의: garden@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     },
     'terrarium-clinic': {
       title: '테라리움 클리닉',
       subtitle: '자신만의 미니 정원을 디자인하고 오래도록 건강하게 돌보는 클래스.',
       ctaHref: 'https://forms.gle/5TerrariumClinic',
-      ctaLabel: '신청 하기',
+      ctaLabel: '신청하기',
       gallery: [
         { src: 'assets/img/가든센터.jpg', alt: '테라리움 재료를 고르는 참가자' },
         { src: 'assets/img/카페.jpg', alt: '완성된 테라리움을 감상하는 모습' },
@@ -287,7 +287,7 @@
             <li>작품 운반용 에코백 (현장 구매 가능)</li>
           </ul>
         </section>
-        <section class="program-modal__section">
+        <aside class="program-modal__notice">
           <h4 class="program-modal__section-title">안내 사항</h4>
           <ul class="program-modal__list">
             <li>어린이는 보호자 동반 시 참여 가능합니다.</li>
@@ -295,7 +295,7 @@
             <li>예약 변경은 3일 전까지 가능합니다.</li>
           </ul>
           <p class="program-modal__note">문의: garden@gasirim.kr / 070-4281-0906</p>
-        </section>
+        </aside>
       `
     }
   };

--- a/assets/js/space-modal.js
+++ b/assets/js/space-modal.js
@@ -30,8 +30,8 @@
     emblaInstance = EmblaCarousel(modal.querySelector('.embla__viewport'), { loop: true });
     const prev = modal.querySelector('.embla__prev');
     const next = modal.querySelector('.embla__next');
-    prev.onclick = emblaInstance.scrollPrev;
-    next.onclick = emblaInstance.scrollNext;
+    if (prev) prev.onclick = () => emblaInstance?.scrollPrev();
+    if (next) next.onclick = () => emblaInstance?.scrollNext();
   }
 
   function closeModal() {
@@ -44,10 +44,39 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('#panel-facility-detail .space-card, #panel-garden-detail .space-card').forEach(card => {
-      card.addEventListener('click', () => openModal(card));
+  const applyFilter = (filter, cards) => {
+    cards.forEach(card => {
+      const matches = filter === 'all' || card.dataset.spaceType === filter;
+      card.classList.toggle('is-hidden', !matches);
     });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const cards = Array.from(document.querySelectorAll('[data-space-gallery] .space-card'));
+    cards.forEach(card => {
+      card.addEventListener('click', () => openModal(card));
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openModal(card);
+        }
+      });
+    });
+
+    const filterButtons = Array.from(document.querySelectorAll('[data-space-filter]'));
+    if (filterButtons.length) {
+      filterButtons.forEach(button => {
+        button.addEventListener('click', () => {
+          const filter = button.dataset.spaceFilter || 'all';
+          filterButtons.forEach(btn => {
+            const isActive = btn === button;
+            btn.classList.toggle('is-active', isActive);
+            btn.setAttribute('aria-pressed', String(isActive));
+          });
+          applyFilter(filter, cards);
+        });
+      });
+    }
 
     document.getElementById('space-modal').addEventListener('click', (e) => {
       if (e.target === e.currentTarget) closeModal();
@@ -62,5 +91,15 @@
         closeModal();
       }
     });
+
+    if (filterButtons.length) {
+      const active = filterButtons.find(btn => btn.classList.contains('is-active')) || filterButtons[0];
+      filterButtons.forEach(btn => {
+        const isActive = btn === active;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
+      });
+      applyFilter(active ? active.dataset.spaceFilter || 'all' : 'all', cards);
+    }
   });
 })();

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -3,55 +3,53 @@
   <div class="footer-divider"></div>
 
   <div class="footer-left">
-    <img class="footer-logo" src="https://via.placeholder.com/119x38?text=Logo" alt="가시림 로고" width="119" height="38" />
+    <img class="footer-logo" src="./assets/img/logo_text_white.png" alt="가시림 로고" width="160" height="48" />
 
     <address class="footer-contact">
-      Phone: <a href="tel:01234567890">012-3456-7890</a><br />
-      Address: <a href="https://maps.google.com/" target="_blank" rel="noopener noreferrer">
-        123 Gasirim Road, Jeju, South Korea
-      </a>
+      <span class="footer-contact__item">전화 <a href="tel:07042810906">070-4281-0906</a></span>
+      <span class="footer-contact__item">주소 <a href="https://maps.google.com/?q=가시림" target="_blank" rel="noopener noreferrer">제주특별자치도 제주시 애월읍 가시림길 10</a></span>
+      <span class="footer-contact__item">이메일 <a href="mailto:hello@gasirim.kr">hello@gasirim.kr</a></span>
     </address>
 
     <div class="footer-social">
-      <a href="https://instagram.com/jeju_gasirim/" aria-label="Instagram" class="social-btn" target="_blank" rel="noopener noreferrer">
+      <a href="https://instagram.com/jeju_gasirim" aria-label="Instagram" class="social-btn" target="_blank" rel="noopener noreferrer">
         <svg viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false">
-          <rect x="3" y="3" width="18" height="18" rx="5"/>
-          <circle cx="12" cy="12" r="4"/>
-          <circle cx="17.5" cy="6.5" r="1.5"/>
+          <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5A5.5 5.5 0 1 1 6.5 13 5.5 5.5 0 0 1 12 7.5Zm0 2A3.5 3.5 0 1 0 15.5 13 3.5 3.5 0 0 0 12 9.5Zm6.75-3.75a1.25 1.25 0 1 1-1.25 1.25 1.25 1.25 0 0 1 1.25-1.25Z"/>
         </svg>
       </a>
-      <a href="https://youtube.com/" aria-label="YouTube" class="social-btn" target="_blank" rel="noopener noreferrer">
+      <a href="https://www.youtube.com/" aria-label="YouTube" class="social-btn" target="_blank" rel="noopener noreferrer">
         <svg viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false">
-          <path d="M22 12s0-3.5-.44-5.14A3 3 0 0 0 19.86 4.3C18.2 3.86 12 3.86 12 3.86s-6.2 0-7.86.44A3 3 0 0 0 2.44 6.86C2 8.5 2 12 2 12s0 3.5.44 5.14a3 3 0 0 0 1.7 2.56C5.8 20.14 12 20.14 12 20.14s6.2 0 7.86-.44a3 3 0 0 0 1.7-2.56C22 15.5 22 12 22 12Z"/>
-          <path d="M10 15.5v-7l6 3.5-6 3.5Z"/>
+          <path d="M21.6 6.2a2.5 2.5 0 0 0-1.76-1.77C18.1 4 12 4 12 4s-6.1 0-7.84.43A2.5 2.5 0 0 0 2.4 6.2 26.7 26.7 0 0 0 2 12a26.7 26.7 0 0 0 .4 5.8 2.5 2.5 0 0 0 1.76 1.77C5.9 20 12 20 12 20s6.1 0 7.84-.43A2.5 2.5 0 0 0 21.6 17.8 26.7 26.7 0 0 0 22 12a26.7 26.7 0 0 0-.4-5.8ZM10.5 15.3V8.7L16 12Z"/>
         </svg>
       </a>
-      <a href="https://facebook.com/" aria-label="Facebook" class="social-btn" target="_blank" rel="noopener noreferrer">
+      <a href="https://pf.kakao.com/" aria-label="KakaoTalk" class="social-btn" target="_blank" rel="noopener noreferrer">
         <svg viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false">
-          <path d="M13.5 22v-8h2.7l.4-3h-3.1V9.2c0-.9.3-1.5 1.6-1.5H17V5.1c-.3 0-1.3-.1-2.4-.1-2.4 0-4 .9-4 3.6V11H7.9v3h2.7v8h2.9Z"/>
+          <path d="M12 3.5c-5.11 0-9.25 3.25-9.25 7.26 0 2.66 1.9 4.97 4.75 6.16L6 21.5l4.4-3.06c.51.06 1.03.09 1.56.09 5.11 0 9.25-3.25 9.25-7.26S17.11 3.5 12 3.5Z"/>
+          <path d="M8.1 10.06h1.34v3.27H8.1Zm3.06 0h1.24l.02 1.73 1.41-1.73h1.35l-1.63 1.87 1.7 2.01h-1.42l-1.39-1.69-.04 1.69h-1.24Zm-4.82 0H5v3.27h1.34Zm9.68 0h-1.44v3.27h1.44Zm-5.73-.88a.88.88 0 1 1-.88-.88.88.88 0 0 1 .88.88Z" fill="#fff"/>
         </svg>
       </a>
     </div>
   </div>
 
-  <nav class="footer-col col-1" aria-label="About links">
-    <h4 class="footer-topic">About</h4>
-    <a class="footer-link" href="/about">About Gasirim</a>
-    <a class="footer-link" href="/map">Arboretum Map</a>
-    <a class="footer-link" href="/tour">Virtual Tour</a>
+  <nav class="footer-col" aria-label="소개 메뉴">
+    <h4 class="footer-topic">소개</h4>
+    <a class="footer-link" href="소개.html#공간소개">공간 소개</a>
+    <a class="footer-link" href="소개.html#수목원지도">수목원 지도</a>
+    <a class="footer-link" href="소개.html#둘러보기">둘러보기</a>
   </nav>
 
-  <nav class="footer-col col-2" aria-label="Visit links">
-    <h4 class="footer-topic">Visit</h4>
-    <a class="footer-link" href="/visit">Visitor Info</a>
-    <a class="footer-link" href="/directions">Directions</a>
-    <a class="footer-link" href="/group">Group Inquiries</a>
+  <nav class="footer-col" aria-label="방문 메뉴">
+    <h4 class="footer-topic">방문</h4>
+    <a class="footer-link" href="방문.html#이용안내">이용 안내</a>
+    <a class="footer-link" href="방문.html#오시는길">오시는 길</a>
+    <a class="footer-link" href="방문.html#단체문의">단체 문의</a>
   </nav>
 
-  <nav class="footer-col col-3" aria-label="Programs links">
-    <h4 class="footer-topic">Programs</h4>
-    <a class="footer-link" href="/programs/walk">Walking Meditation</a>
-    <a class="footer-link" href="/programs/meditation">Meditation</a>
-    <a class="footer-link" href="/programs/gardening">Gardening</a>
+  <nav class="footer-col" aria-label="프로그램 메뉴">
+    <h4 class="footer-topic">프로그램</h4>
+    <a class="footer-link" href="프로그램.html">전체 프로그램</a>
+    <a class="footer-link" href="산책명상.html">산책 명상</a>
+    <a class="footer-link" href="명상.html">명상</a>
+    <a class="footer-link" href="원예.html">원예</a>
   </nav>
 </footer>

--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -28,8 +28,7 @@
     </div>
     <div class="embla__overlay">
       <div class="embla__copy">
-        <h1>제주가 품은 정원, 마음을 여는 공간</h1>
-        <p><span class="text-variable">제주 민간 4호 정원, 가시림</span></p>
+        <h1>제주가 품은 정원,<br><span>마음을 여는 공간</span></h1>
       </div>
       <div class="embla__asset-text">
         <p class="asset-text is-active" data-index="0"><a href="/gasirim.github.io/">오름 정원</a></p>

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -15,8 +15,7 @@
     </div>
     <div class="embla__overlay">
       <div class="embla__copy">
-        <h1>제주가 품은 정원, 마음을 여는 공간</h1>
-        <p><span class="text-variable">제주 민간 4호 정원, 가시림</span></p>
+        <h1>제주가 품은 정원,<br><span>마음을 여는 공간</span></h1>
       </div>
     </div>
   </div>

--- a/shop.html
+++ b/shop.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
     <main class="shop-main" aria-labelledby="shop-heading">
       <section class="shop-overview">
         <div class="shop-overview__inner">

--- a/공간소개.html
+++ b/공간소개.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/단체문의.html
+++ b/단체문의.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/둘러보기.html
+++ b/둘러보기.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/명상.html
+++ b/명상.html
@@ -20,6 +20,7 @@
 <body>
   <div class="page">
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="program-main" aria-labelledby="meditation-program-heading">
       <section class="program-hero">

--- a/방문.html
+++ b/방문.html
@@ -17,442 +17,28 @@
   <link rel="stylesheet" href="assets/css/globals.css" />
   <link rel="stylesheet" href="assets/css/style.css" />
 
-  <style>
-    :root {
-      --visit-ink: #1a1f1c;
-      --visit-muted: rgba(26, 31, 28, 0.7);
-      --visit-accent: #446652;
-      --visit-highlight: rgba(124, 164, 140, 0.15);
-      --visit-blur: blur(60px);
-    }
-
-    .visit-page {
-      display: flex;
-      flex-direction: column;
-      gap: clamp(72px, 9vw, 120px);
-      padding: clamp(120px, 18vh, 220px) 0 clamp(96px, 16vh, 160px);
-      background: radial-gradient(circle at top right, rgba(124, 164, 140, 0.12), transparent 45%),
-        radial-gradient(circle at bottom left, rgba(171, 196, 177, 0.18), transparent 52%),
-        #f9f8f3;
-      color: var(--visit-ink);
-    }
-
-    .visit-container {
-      width: min(1120px, calc(100% - 2 * var(--page-pad)));
-      margin: 0 auto;
-      padding: 0 var(--page-pad);
-    }
-
-    .visit-hero {
-      position: relative;
-      isolation: isolate;
-      overflow: hidden;
-      border-radius: clamp(26px, 4vw, 38px);
-      background: linear-gradient(135deg, rgba(37, 63, 48, 0.92), rgba(25, 44, 36, 0.88)),
-        url('assets/img/유리온실.jpg') center/cover no-repeat;
-      min-height: clamp(360px, 48vh, 520px);
-      color: #f4f3ee;
-      box-shadow: 0 30px 80px rgba(13, 27, 19, 0.32);
-    }
-
-    .visit-hero::before,
-    .visit-hero::after {
-      content: "";
-      position: absolute;
-      border-radius: 999px;
-      filter: var(--visit-blur);
-      opacity: 0.6;
-      pointer-events: none;
-      animation: floaty 24s linear infinite;
-    }
-
-    .visit-hero::before {
-      width: clamp(220px, 32vw, 320px);
-      height: clamp(220px, 32vw, 320px);
-      background: radial-gradient(circle, rgba(175, 214, 185, 0.9), transparent 70%);
-      top: clamp(-70px, -6vw, -30px);
-      right: clamp(-80px, -4vw, -24px);
-    }
-
-    .visit-hero::after {
-      width: clamp(260px, 34vw, 360px);
-      height: clamp(260px, 34vw, 360px);
-      background: radial-gradient(circle, rgba(208, 188, 151, 0.95), transparent 72%);
-      bottom: clamp(-120px, -12vw, -60px);
-      left: clamp(-100px, -8vw, -32px);
-      animation-direction: reverse;
-    }
-
-    .visit-hero__content {
-      position: relative;
-      z-index: 2;
-      padding: clamp(48px, 7vw, 80px);
-      display: flex;
-      flex-direction: column;
-      gap: clamp(20px, 2vw, 28px);
-      max-width: min(560px, 90%);
-    }
-
-    .visit-hero__eyebrow {
-      font-family: var(--font-sans);
-      font-size: 0.9rem;
-      letter-spacing: 0.3em;
-      text-transform: uppercase;
-      color: rgba(244, 243, 238, 0.75);
-    }
-
-    .visit-hero h1 {
-      font-family: var(--font-mincho);
-      font-size: clamp(2.3rem, 4vw, 3.2rem);
-      font-weight: 400;
-      line-height: 1.2;
-      letter-spacing: -0.015em;
-    }
-
-    .visit-hero p {
-      font-family: var(--font-sans);
-      font-size: clamp(1.05rem, 1.5vw, 1.2rem);
-      line-height: 1.8;
-      color: rgba(244, 243, 238, 0.85);
-    }
-
-    .visit-hero__chips {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      margin-top: 0.75rem;
-    }
-
-    .visit-chip {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.65rem 1.4rem;
-      border-radius: 999px;
-      background: rgba(248, 246, 240, 0.16);
-      color: inherit;
-      font-size: 0.95rem;
-      font-weight: 500;
-      text-decoration: none;
-      border: 1px solid rgba(244, 243, 238, 0.28);
-      backdrop-filter: blur(12px);
-      transition: transform 0.35s ease, background 0.35s ease, border 0.35s ease;
-    }
-
-    .visit-chip:hover {
-      transform: translateY(-4px);
-      background: rgba(248, 246, 240, 0.28);
-      border-color: rgba(244, 243, 238, 0.48);
-    }
-
-    .visit-section {
-      display: grid;
-      gap: clamp(32px, 5vw, 48px);
-    }
-
-    .visit-section__header {
-      max-width: 640px;
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    .visit-section__label {
-      font-size: 0.85rem;
-      letter-spacing: 0.35em;
-      text-transform: uppercase;
-      font-weight: 600;
-      color: rgba(26, 31, 28, 0.48);
-    }
-
-    .visit-section__title {
-      font-family: var(--font-mincho);
-      font-size: clamp(2.1rem, 3vw, 2.8rem);
-      font-weight: 400;
-      letter-spacing: -0.01em;
-    }
-
-    .visit-section__lead {
-      font-family: var(--font-sans);
-      font-size: 1.05rem;
-      line-height: 1.8;
-      color: var(--visit-muted);
-    }
-
-    .visit-grid {
-      display: grid;
-      gap: clamp(20px, 3vw, 28px);
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    }
-
-    .visit-card {
-      position: relative;
-      padding: clamp(24px, 4vw, 32px);
-      border-radius: clamp(18px, 3vw, 24px);
-      background: rgba(255, 255, 255, 0.82);
-      box-shadow: 0 24px 60px rgba(31, 46, 36, 0.1);
-      border: 1px solid rgba(103, 132, 112, 0.22);
-      backdrop-filter: blur(18px);
-      display: grid;
-      gap: 1rem;
-      overflow: hidden;
-    }
-
-    .visit-card::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      background: radial-gradient(circle at top left, rgba(124, 164, 140, 0.18), transparent 60%);
-      opacity: 0;
-      transition: opacity 0.45s ease;
-      pointer-events: none;
-    }
-
-    .visit-card:hover::before {
-      opacity: 1;
-    }
-
-    .visit-card h3 {
-      font-family: var(--font-sans);
-      font-size: 1.2rem;
-      font-weight: 600;
-      color: var(--visit-ink);
-    }
-
-    .visit-card p,
-    .visit-card li {
-      font-size: 1rem;
-      line-height: 1.7;
-      color: var(--visit-muted);
-    }
-
-    .visit-card ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 0.65rem;
-    }
-
-    .visit-card ul li::before {
-      content: "•";
-      color: var(--visit-accent);
-      margin-right: 0.6rem;
-      font-weight: 600;
-    }
-
-    .visit-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.35rem 0.75rem;
-      border-radius: 999px;
-      background: rgba(68, 102, 82, 0.12);
-      color: var(--visit-accent);
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
-    }
-
-    .visit-map {
-      position: relative;
-      border-radius: clamp(24px, 4vw, 32px);
-      overflow: hidden;
-      box-shadow: 0 40px 100px rgba(13, 27, 19, 0.18);
-      background: rgba(255, 255, 255, 0.6);
-      border: 1px solid rgba(68, 102, 82, 0.18);
-      min-height: 320px;
-    }
-
-    .visit-map iframe {
-      width: 100%;
-      height: 100%;
-      border: 0;
-      filter: saturate(1.1) contrast(0.97);
-    }
-
-    .visit-map__badge {
-      position: absolute;
-      top: 18px;
-      right: 18px;
-      background: rgba(16, 29, 22, 0.88);
-      color: #f3f2ee;
-      padding: 0.55rem 1rem;
-      border-radius: 999px;
-      font-size: 0.85rem;
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-      backdrop-filter: blur(12px);
-    }
-
-    .visit-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 14px;
-    }
-
-    .visit-button {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.65rem;
-      padding: 0.85rem 1.6rem;
-      border-radius: 999px;
-      font-size: 0.95rem;
-      font-weight: 600;
-      text-decoration: none;
-      transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
-    }
-
-    .visit-button--primary {
-      background: #f4f2ea;
-      color: var(--visit-ink);
-      box-shadow: 0 18px 40px rgba(16, 29, 22, 0.15);
-    }
-
-    .visit-button--primary:hover {
-      transform: translateY(-4px);
-      background: #fffdf5;
-      box-shadow: 0 24px 60px rgba(16, 29, 22, 0.2);
-    }
-
-    .visit-button--ghost {
-      border: 1px solid rgba(26, 31, 28, 0.16);
-      color: var(--visit-ink);
-      background: rgba(255, 255, 255, 0.6);
-      backdrop-filter: blur(14px);
-    }
-
-    .visit-button--ghost:hover {
-      transform: translateY(-4px);
-      border-color: rgba(26, 31, 28, 0.34);
-      background: rgba(255, 255, 255, 0.85);
-    }
-
-    .contact-grid {
-      display: grid;
-      gap: clamp(20px, 3vw, 28px);
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    }
-
-    .contact-card {
-      padding: clamp(22px, 3.5vw, 28px);
-      border-radius: clamp(18px, 3vw, 24px);
-      background: rgba(255, 255, 255, 0.9);
-      border: 1px solid rgba(68, 102, 82, 0.18);
-      box-shadow: 0 20px 50px rgba(31, 46, 36, 0.12);
-      display: grid;
-      gap: 0.65rem;
-    }
-
-    .contact-card span {
-      font-size: 0.85rem;
-      letter-spacing: 0.2em;
-      text-transform: uppercase;
-      color: rgba(26, 31, 28, 0.4);
-      font-weight: 600;
-    }
-
-    .contact-card a {
-      color: var(--visit-accent);
-      text-decoration: none;
-      font-weight: 600;
-    }
-
-    .contact-card a:hover {
-      text-decoration: underline;
-    }
-
-    [data-animate] {
-      opacity: 0;
-      transform: translateY(32px);
-      animation: riseFade 0.9s cubic-bezier(0.23, 0.92, 0.34, 1) forwards;
-      animation-delay: var(--delay, 0s);
-    }
-
-    .visit-hero[data-animate] {
-      transform: translateY(18px);
-    }
-
-    @keyframes riseFade {
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    @keyframes floaty {
-      0% {
-        transform: translate3d(0, 0, 0) scale(1);
-      }
-      50% {
-        transform: translate3d(12px, -18px, 0) scale(1.04);
-      }
-      100% {
-        transform: translate3d(0, 0, 0) scale(1);
-      }
-    }
-
-    @media (max-width: 960px) {
-      .visit-page {
-        padding-top: clamp(120px, 22vh, 200px);
-      }
-
-      .visit-hero {
-        border-radius: clamp(22px, 6vw, 32px);
-      }
-    }
-
-    @media (max-width: 640px) {
-      .visit-hero__content {
-        padding: clamp(36px, 10vw, 52px);
-      }
-
-      .visit-chip {
-        padding: 0.55rem 1.1rem;
-      }
-
-      .visit-section__title {
-        font-size: clamp(1.9rem, 6vw, 2.4rem);
-      }
-
-      .visit-map__badge {
-        position: static;
-        margin: 18px;
-        align-self: flex-start;
-      }
-
-      .visit-map {
-        min-height: 280px;
-      }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .visit-chip,
-      .visit-button,
-      .visit-card::before,
-      .visit-hero::before,
-      .visit-hero::after,
-      .visit-page,
-      [data-animate] {
-        transition: none !important;
-        animation: none !important;
-      }
-
-      [data-animate] {
-        opacity: 1 !important;
-        transform: none !important;
-      }
-    }
-  </style>
+  
 </head>
 <body>
   <div class="page">
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
-    <main class="visit-page" aria-labelledby="visit-heading">
-      <section id="이용안내" class="visit-section visit-container" aria-labelledby="section-usage" data-animate style="--delay: 0.15s">
+    <main class="visit-main" aria-labelledby="visit-heading">
+      <section class="visit-hero" aria-labelledby="visit-heading">
+        <div class="visit-hero__copy">
+          <p class="visit-hero__eyebrow">Visit</p>
+          <h1 id="visit-heading">방문 안내</h1>
+          <p class="visit-hero__lead">가시림을 더 깊이 즐길 수 있는 운영 시간, 이용 요금, 오시는 길, 단체 예약 정보를 한 곳에 모았습니다. 계획에 맞춰 편안하게 방문해 보세요.</p>
+          <div class="visit-hero__chips">
+            <a class="visit-chip" href="#이용안내">이용 안내</a>
+            <a class="visit-chip" href="#오시는길">오시는 길</a>
+            <a class="visit-chip" href="#단체문의">단체 문의</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="이용안내" class="visit-section" aria-labelledby="section-usage">
         <div class="visit-section__header">
           <span class="visit-section__label">Information</span>
           <h2 id="section-usage" class="visit-section__title">이용 시간 및 요금 안내</h2>
@@ -461,7 +47,7 @@
         <div class="visit-grid">
           <article class="visit-card">
             <span class="visit-badge">운영 시간</span>
-            <h3>매일 09:00 – 18:00</h3>
+            <p class="visit-card__title">매일 09:00 – 18:00</p>
             <p>마지막 입장은 17:00까지 가능합니다. 폭우나 강풍 등 기상 상황에 따라 운영 시간이 변동될 수 있으니 방문 전 공지 사항을 확인해 주세요.</p>
             <ul>
               <li>사전 예약 없이 현장 입장 가능</li>
@@ -470,7 +56,7 @@
           </article>
           <article class="visit-card">
             <span class="visit-badge">이용 요금</span>
-            <h3>연령별 요금 안내</h3>
+            <p class="visit-card__title">연령별 요금 안내</p>
             <ul>
               <li>일반: 12,000원</li>
               <li>청소년·경로: 9,000원</li>
@@ -480,7 +66,7 @@
           </article>
           <article class="visit-card">
             <span class="visit-badge">방문 Tip</span>
-            <h3>자연을 즐기는 방법</h3>
+            <p class="visit-card__title">자연을 즐기는 방법</p>
             <ul>
               <li>계절별 추천 코스를 안내 데스크에서 받아보세요</li>
               <li>편안한 산책을 위해 편한 신발과 얇은 겉옷을 준비하세요</li>
@@ -490,7 +76,7 @@
         </div>
       </section>
 
-      <section id="오시는길" class="visit-section visit-container" aria-labelledby="section-directions" data-animate style="--delay: 0.25s">
+      <section id="오시는길" class="visit-section" aria-labelledby="section-directions">
         <div class="visit-section__header">
           <span class="visit-section__label">Directions</span>
           <h2 id="section-directions" class="visit-section__title">오시는 길</h2>
@@ -498,7 +84,7 @@
         </div>
         <div class="visit-grid">
           <article class="visit-card">
-            <h3>대중교통 안내</h3>
+            <p class="visit-card__title">대중교통 안내</p>
             <p>제주공항에서 182번 버스를 이용해 ‘가시림입구’ 정류장에서 하차하신 후 도보 8분이면 가시림에 도착합니다. 택시 이용 시 기사님께 ‘가시림 수목원’을 말씀해 주세요.</p>
             <div class="visit-actions">
               <a class="visit-button visit-button--primary" href="tel:0640000000">064-000-0000 문의</a>
@@ -512,7 +98,7 @@
         </div>
       </section>
 
-      <section id="단체문의" class="visit-section visit-container" aria-labelledby="section-group" data-animate style="--delay: 0.35s">
+      <section id="단체문의" class="visit-section" aria-labelledby="section-group">
         <div class="visit-section__header">
           <span class="visit-section__label">Group Booking</span>
           <h2 id="section-group" class="visit-section__title">단체 예약 및 대관 문의</h2>

--- a/산책명상.html
+++ b/산책명상.html
@@ -20,6 +20,7 @@
 <body>
   <div class="page">
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="program-main" aria-labelledby="walk-program-heading">
       <section class="program-hero">

--- a/소개.html
+++ b/소개.html
@@ -37,37 +37,173 @@
 
       <!-- 공간소개 -->
       <section id="공간소개" class="tab-panel" role="tabpanel" tabindex="0">
-        <!-- Toggle Button -->
-        <div class="space-tabs reveal parallax from-up" data-tabs role="tablist" aria-label="공간소개 분류">
-          <button class="tab-button active" role="tab" id="tab-facility" aria-controls="panel-facility-detail" aria-selected="true">시설</button>
-          <button class="tab-button" role="tab" id="tab-garden-detail" aria-controls="panel-garden-detail" aria-selected="false">정원</button>
+        <div class="space-filters shop-filters" role="group" aria-label="공간 소개 분류">
+          <button type="button" class="shop-filter is-active" data-space-filter="all">All</button>
+          <button type="button" class="shop-filter" data-space-filter="facility">시설</button>
+          <button type="button" class="shop-filter" data-space-filter="garden">정원</button>
         </div>
-        <!-- 시설 공간 소개 -->
-        <section id="panel-facility-detail" class="tab-panel" role="tabpanel" tabindex="0">
-          <div class="cards reveal parallax from-up" height="409px">
-            <article class="space-card" data-images="assets/img/유리온실.jpg,assets/img/유리온실2.jpg" data-title="유리온실" data-desc="유리온실에 관한 설명입니다.">
-              <img src="assets/img/유리온실.jpg" alt="유리온실 이미지" class="space-card-img"/>
-              <h3 class="space-card-title">유리온실</h3>
-            </article>
-            <article class="space-card" data-images="assets/img/카페.jpg,assets/img/가든센터.jpg" data-title="카페" data-desc="카페에 관한 설명입니다.">
-              <img src="assets/img/카페.jpg" alt="카페 이미지" class="space-card-img"/>
-              <h3 class="space-card-title">카페</h3>
-            </article>
-          </div>
-        </section>
-        <!-- 정원 공간 소개 -->
-        <section id="panel-garden-detail" class="tab-panel" role="tabpanel" tabindex="0" hidden>
-          <div class="cards reveal parallax from-up" height="409px">
-            <article class="space-card" data-images="assets/img/가든센터.jpg,assets/img/유리온실.jpg" data-title="가든센터" data-desc="가든센터에 관한 설명입니다.">
-              <img src="assets/img/가든센터.jpg" alt="가든센터 이미지" class="space-card-img"/>
-              <h3 class="space-card-title">가든센터</h3>
-            </article>
-            <article class="space-card" data-images="assets/img/main.jpg,assets/img/유리온실2.jpg" data-title="정원" data-desc="정원 카드에 관한 설명입니다.">
-              <img src="assets/img/main.jpg" alt="정원 이미지" class="space-card-img"/>
-              <h3 class="space-card-title">정원</h3>
-            </article>
-          </div>
-        </section>
+
+        <div class="space-gallery" data-space-gallery>
+          <article class="space-card" role="button" tabindex="0" data-space-type="facility" data-images="assets/img/유리온실.jpg,assets/img/유리온실2.jpg,assets/img/가든센터.jpg" data-title="유리 온실" data-desc="사계절 식물이 숨 쉬는 가시림의 중심 온실입니다. 계절별 테마 전시와 명상 클래스가 열립니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실.jpg" alt="가시림 유리 온실 내부" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">유리 온실</h3>
+              <p class="space-card__summary">사계절 꽃과 열대 식물을 감상하며 휴식을 취할 수 있는 메인 온실.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="facility" data-images="assets/img/가든센터.jpg,assets/img/유리온실.jpg,assets/img/유리온실2.jpg" data-title="가든센터" data-desc="정원 관리 노하우와 계절 식물을 만날 수 있는 가시림의 안내 센터입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/가든센터.jpg" alt="가시림 가든센터 외관" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">가든센터</h3>
+              <p class="space-card__summary">입장 안내와 가드닝 클래스를 진행하는 허브 공간.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="facility" data-images="assets/img/유리온실2.jpg,assets/img/main.jpg,assets/img/카페.jpg" data-title="마음 온실 스튜디오" data-desc="온실 안쪽에 마련된 조용한 스튜디오로, 명상과 요가 프로그램이 운영됩니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="마음 온실 스튜디오 전경" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">마음 온실 스튜디오</h3>
+              <p class="space-card__summary">온실 속 깊은 휴식을 위한 전용 명상 스튜디오.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="facility" data-images="assets/img/카페.jpg,assets/img/main.jpg,assets/img/가든센터.jpg" data-title="플랜트 카페" data-desc="제철 허브와 티를 즐길 수 있는 카페와 숍으로, 가시림의 시그니처 음료를 제공합니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/카페.jpg" alt="가시림 플랜트 카페" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">플랜트 카페</h3>
+              <p class="space-card__summary">허브 티와 가드닝 굿즈를 만나는 라이프스타일 카페.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/main.jpg,assets/img/유리온실.jpg,assets/img/카페.jpg" data-title="메타세쿼이아 숲길" data-desc="하늘을 가득 메우는 메타세쿼이아가 조성하는 산책길로, 새벽 명상 프로그램이 진행됩니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/main.jpg" alt="메타세쿼이아 숲길" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">메타세쿼이아 숲길</h3>
+              <p class="space-card__summary">사계절 내내 깊은 숲 향을 느낄 수 있는 대표 산책 코스.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/가든센터.jpg,assets/img/유리온실2.jpg,assets/img/main.jpg" data-title="오름 정원" data-desc="제주의 오름을 모티프로 설계한 입체 정원으로, 화산석과 토종 식물을 감상할 수 있습니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/가든센터.jpg" alt="오름 정원" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">오름 정원</h3>
+              <p class="space-card__summary">제주 오름 지형을 재현한 테라스형 정원.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/main.jpg,assets/img/카페.jpg,assets/img/유리온실.jpg" data-title="수국 정원" data-desc="초여름이 되면 색색의 수국이 만개해 가장 화려한 풍경을 선사하는 인기 포토 스팟입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/main.jpg" alt="수국 정원" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">수국 정원</h3>
+              <p class="space-card__summary">초여름을 수놓는 화려한 컬러의 수국 군락.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/유리온실2.jpg,assets/img/가든센터.jpg,assets/img/main.jpg" data-title="팜파스 그라스 필드" data-desc="바람에 따라 부드럽게 물결치는 팜파스 그라스로 가을 감성을 담은 산책이 가능합니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="팜파스 그라스 필드" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">팜파스 그라스 필드</h3>
+              <p class="space-card__summary">황금빛 억새가 드넓게 펼쳐지는 가을 정원.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/main.jpg,assets/img/유리온실.jpg,assets/img/카페.jpg" data-title="곶자왈 생태숲" data-desc="제주의 곶자왈 생태계를 그대로 옮겨온 구역으로, 희귀 이끼와 야생화가 어우러져 있습니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/main.jpg" alt="곶자왈 생태숲" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">곶자왈 생태숲</h3>
+              <p class="space-card__summary">토종 생물을 보호하는 프라이빗 숲 구역.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/카페.jpg,assets/img/main.jpg,assets/img/유리온실2.jpg" data-title="햇살 마당" data-desc="탁 트인 잔디 광장으로, 가족 피크닉과 야외 클래스가 열리는 열린 공간입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/카페.jpg" alt="햇살 마당" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">햇살 마당</h3>
+              <p class="space-card__summary">주말 피크닉과 야외 클래스가 열리는 잔디 마당.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/유리온실.jpg,assets/img/main.jpg,assets/img/가든센터.jpg" data-title="치유 산책로" data-desc="편안한 동선과 다양한 향기 식물이 배치된 테라피 산책로입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실.jpg" alt="치유 산책로" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">치유 산책로</h3>
+              <p class="space-card__summary">향기 식물과 함께 걷는 테라피 코스.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/가든센터.jpg,assets/img/카페.jpg,assets/img/유리온실2.jpg" data-title="명상 화원" data-desc="명상 클래스 전에 호흡을 정돈하는 화단으로, 계절 꽃과 허브가 어우러져 있습니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/가든센터.jpg" alt="명상 화원" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">명상 화원</h3>
+              <p class="space-card__summary">차분한 호흡을 돕는 명상 전용 플랜팅 존.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/유리온실2.jpg,assets/img/유리온실.jpg,assets/img/main.jpg" data-title="원예 실험포" data-desc="원예 프로그램을 체험할 수 있는 실습 구역으로, 다양한 감각원예 수업이 열립니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실2.jpg" alt="원예 실험포" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">원예 실험포</h3>
+              <p class="space-card__summary">감각원예 수업과 체험이 이루어지는 실습 정원.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/main.jpg,assets/img/가든센터.jpg,assets/img/유리온실.jpg" data-title="별빛 정원" data-desc="밤이 되면 은은한 조명이 켜져 야간 산책에 어울리는 로맨틱한 정원입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/main.jpg" alt="별빛 정원" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">별빛 정원</h3>
+              <p class="space-card__summary">밤의 조명과 어우러진 로맨틱 산책 정원.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/카페.jpg,assets/img/유리온실.jpg,assets/img/유리온실2.jpg" data-title="향기 허브 테라스" data-desc="온실과 연결된 허브 테라스로, 직접 수확한 허브를 활용한 티 클래스가 운영됩니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/카페.jpg" alt="향기 허브 테라스" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">향기 허브 테라스</h3>
+              <p class="space-card__summary">허브 향으로 가득한 온실 옆 테라스.</p>
+            </div>
+          </article>
+
+          <article class="space-card" role="button" tabindex="0" data-space-type="garden" data-images="assets/img/유리온실.jpg,assets/img/main.jpg,assets/img/카페.jpg" data-title="수생 식물 연못" data-desc="연과 수생 식물을 감상하며 휴식할 수 있는 수변 공간입니다.">
+            <figure class="space-card__media">
+              <img src="assets/img/유리온실.jpg" alt="수생 식물 연못" loading="lazy"/>
+            </figure>
+            <div class="space-card__body">
+              <h3 class="space-card__title">수생 식물 연못</h3>
+              <p class="space-card__summary">물소리와 함께 머무는 힐링 수변 정원.</p>
+            </div>
+          </article>
+        </div>
       </section>
 
       <!-- 수목원 지도 -->

--- a/수목원지도.html
+++ b/수목원지도.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/오시는길.html
+++ b/오시는길.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/원예.html
+++ b/원예.html
@@ -20,6 +20,7 @@
 <body>
   <div class="page">
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="program-main" aria-labelledby="gardening-program-heading">
       <section class="program-hero">

--- a/이용안내.html
+++ b/이용안내.html
@@ -25,6 +25,7 @@
     
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->
     <section class="body-container" aria-labelledby="intro-heading">

--- a/프로그램.html
+++ b/프로그램.html
@@ -24,6 +24,7 @@
   <div class="page">
     <!-- Header -->
     <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="program-main" aria-labelledby="program-heading">
       <section class="program-hero">
@@ -37,6 +38,33 @@
           <figure class="program-hero__media">
             <img src="assets/img/main.jpg" alt="나무 사이로 들어오는 햇살이 비추는 숲길" loading="lazy">
           </figure>
+        </div>
+      </section>
+
+      <section class="program-summary" aria-labelledby="program-summary-heading">
+        <div class="program-summary__header">
+          <h2 id="program-summary-heading">세 가지 시그니처 프로그램</h2>
+          <p class="program-summary__intro">명상과 원예, 산책 명상을 대표하는 핵심 프로그램을 먼저 만나보세요. 각 카드를 클릭하면 세부 안내와 일정, 신청 안내 페이지로 이동합니다.</p>
+        </div>
+        <div class="program-summary__grid">
+          <a class="program-summary__card" href="산책명상.html">
+            <span class="program-summary__badge">WALK</span>
+            <h3>산책 명상</h3>
+            <p class="program-summary__excerpt">새벽 숲을 함께 걸으며 호흡을 여는 가시림 대표 프로그램. 계절마다 달라지는 산책길에서 감각을 깨웁니다.</p>
+            <span class="program-summary__cta">자세히 보기</span>
+          </a>
+          <a class="program-summary__card" href="명상.html">
+            <span class="program-summary__badge">MEDITATION</span>
+            <h3>온실 명상</h3>
+            <p class="program-summary__excerpt">온실 속에서 진행되는 심화 명상 세션으로, 사운드 배스와 촛불 명상 등 다양한 이완 커리큘럼을 제공합니다.</p>
+            <span class="program-summary__cta">자세히 보기</span>
+          </a>
+          <a class="program-summary__card" href="원예.html">
+            <span class="program-summary__badge">GARDENING</span>
+            <h3>감각 원예</h3>
+            <p class="program-summary__excerpt">식물을 직접 돌보고 디자인하며 치유를 경험하는 원예 클래스. 계절 소재를 활용한 실습으로 구성되어 있습니다.</p>
+            <span class="program-summary__cta">자세히 보기</span>
+          </a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- expand 소개.html 공간소개 with unified filter toggles, four 시설 cards, twelve 정원 cards, and a larger embla modal experience
- redesign 프로그램.html with an updated hero, new summary cards, refreshed catalog styling, and richer modal content wiring in main.js
- standardize global typography and spacing while aligning navigation/footer usage across pages, refreshing the shop grid and rebuilding the 방문 안내 layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de5288e9488321aa91e0834f1fef8e