### PR TITLE
Implement static hero headers and polish program UI

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -271,6 +271,63 @@
   }
 }
 
+
+/* ===== Static page hero ===== */
+.page-hero {
+  position: relative;
+  width: 100%;
+  height: min(50vh, 520px);
+  min-height: clamp(240px, 42vh, 420px);
+  margin: 0;
+  overflow: hidden;
+  border-radius: clamp(18px, 4vw, 32px);
+  background: #111;
+}
+
+.page-hero__media {
+  position: absolute;
+  inset: 0;
+}
+
+.page-hero__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.page-hero__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: clamp(32px, 8vw, 96px) clamp(20px, 8vw, 160px);
+  color: #fff;
+  background: linear-gradient(135deg, rgba(0,0,0,0.58) 0%, rgba(0,0,0,0.28) 50%, rgba(0,0,0,0.58) 100%);
+  z-index: 1;
+}
+
+.page-hero__title {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-weight: 400;
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  letter-spacing: -0.02em;
+  text-shadow: 0 12px 32px rgba(0,0,0,0.45);
+}
+
+@media (max-width: 640px) {
+  .page-hero {
+    border-radius: clamp(12px, 5vw, 20px);
+  }
+
+  .page-hero__overlay {
+    padding: clamp(28px, 12vw, 72px) clamp(20px, 8vw, 64px);
+  }
+}
+
 .embla__slide {
   flex: 0 0 100%;
   position: relative;
@@ -291,8 +348,8 @@
   gap: 2rem;
   padding-top: 0;
   padding-bottom: clamp(20px, 15vh, 190px);
-  padding-right: clamp(20px, calc(8vw + max(50px, 3vw) + 28px), 350px);
-  padding-left: clamp(20px, calc(8vw + max(50px, 3vw) + 28px), 350px);
+  padding-right: clamp(20px, 8vw, 350px);
+  padding-left: clamp(20px, 8vw, 350px);
   color: #fff;
   background: linear-gradient(to top, rgba(0,0,0,.8) 0%, rgba(0,0,0,0) 60%);
 }
@@ -303,9 +360,9 @@
 
 .embla__copy h1 {
   margin: 0;
-  font-size: clamp(2.5rem, 8vw, 4rem);
+  font-size: clamp(2.625rem, 9vw, 80px);
   font-weight: 400;
-  line-height: 1.25;
+  line-height: 1.05;
   animation: emblaHeadline 1400ms ease both;
 }
 
@@ -744,6 +801,31 @@
   align-items: center;
   gap: 44px;
 }
+
+.body-container--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(48px, 8vw, 112px);
+}
+
+.body-container--stacked > * {
+  margin: 0;
+}
+
+.body-container--stacked .article-container,
+.body-container--stacked .intro-hero {
+  width: min(86%, 1240px);
+}
+
+.body-container--stacked .intro-hero {
+  margin: 0;
+}
+
+.body-container--stacked .intro-gallery {
+  width: min(86%, 1240px);
+}
+
 
 .article {
   display: flex;
@@ -1920,13 +2002,41 @@ body.modal-open {
 /* ===== 공간 소개 ===== */
 .space-filters {
   justify-content: center;
-  margin-bottom: clamp(32px, 6vw, 48px);
+  margin: 0 auto clamp(32px, 6vw, 48px);
+  width: min(1200px, 100%);
+  padding: 0 var(--page-pad);
+  box-sizing: border-box;
 }
 
 .space-gallery {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: clamp(24px, 4vw, 40px);
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 0 var(--page-pad);
+  box-sizing: border-box;
+}
+
+@media (min-width: 1024px) {
+  .space-gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.garden-map {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 0 var(--page-pad);
+  box-sizing: border-box;
+}
+
+.garden-map img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: clamp(18px, 4vw, 32px);
+  box-shadow: 0 28px 68px rgba(0,0,0,0.18);
 }
 
 .space-card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -712,7 +712,7 @@
       let pendingStart = false;
       const requestedSpeed = Number(gallery.dataset.gallerySpeed);
       const hasExplicitSpeed = Number.isFinite(requestedSpeed) && requestedSpeed > 0;
-      const requestedDuration = Number(gallery.dataset.galleryDuration || 20);
+      const requestedDuration = Number(gallery.dataset.galleryDuration || 35);
       let pixelsPerSecond = hasExplicitSpeed ? requestedSpeed : 0;
       const motionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
       let allowAutoplay = !(motionQuery?.matches);

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div id="landing-header" data-include="partials/header-landing.html"></div>
 
     <!-- 가시림 소개 -->
-    <section class="body-container" aria-labelledby="intro-heading">
+    <section class="body-container body-container--stacked" aria-labelledby="intro-heading">
       <h2 id="intro-heading" class="sr-only">가시림 소개</h2>
 
       <div class="article article-container reveal from-up">

--- a/partials/header-landing.html
+++ b/partials/header-landing.html
@@ -1,5 +1,5 @@
 <a class="brand-title" href="/gasirim.github.io/">
-  <img src="./assets/img/logo_text_white.png" class="brand-logo" />
+  <img src="./assets/img/logo_text_white.png" class="brand-logo" alt="가시림" />
   <!-- <span class="brand-text">
     <span class="brand-name">加 時 林</span>
     <span class="brand-tagline">치유의 정원</span>
@@ -28,7 +28,7 @@
     </div>
     <div class="embla__overlay">
       <div class="embla__copy">
-        <h1>제주가 품은 정원,<br><span>마음을 여는 공간</span></h1>
+        <h1>제주가 품은<br>사계절의 정원<br>가시림</h1>
       </div>
       <div class="embla__asset-text">
         <p class="asset-text is-active" data-index="0"><a href="/gasirim.github.io/">오름 정원</a></p>

--- a/partials/header-shop.html
+++ b/partials/header-shop.html
@@ -1,0 +1,22 @@
+<a class="brand-title" href="/gasirim.github.io/">
+  <img src="./assets/img/logo_text_white.png" class="brand-logo" alt="가시림" />
+  <!-- <span class="brand-text">
+    <span class="brand-name">加 時 林</span>
+    <span class="brand-tagline">치유의 정원</span>
+  </span> -->
+</a>
+<section class="hero-slideshow hero-slideshow--video">
+  <div class="hero-video__container">
+    <div class="intro-hero" data-video>
+      <video class="intro-video" preload="auto" autoplay muted loop playsinline webkit-playsinline disablePictureInPicture controlsList="nodownload noplaybackrate noremoteplayback nofullscreen">
+        <source src="./assets/video/gasirim.mp4" type="video/mp4">
+        비디오를 재생할 수 없는 환경입니다.
+      </video>
+    </div>
+    <div class="embla__overlay">
+      <div class="embla__copy">
+        <h1>제주가 품은<br>사계절의 정원<br>가시림</h1>
+      </div>
+    </div>
+  </div>
+</section>

--- a/partials/header-site.html
+++ b/partials/header-site.html
@@ -1,22 +1,56 @@
 <a class="brand-title" href="/gasirim.github.io/">
-  <img src="./assets/img/logo_text_white.png" class="brand-logo" />
-  <!-- <span class="brand-text">
-    <span class="brand-name">加 時 林</span>
-    <span class="brand-tagline">치유의 정원</span>
-  </span> -->
+  <img src="./assets/img/logo_text_white.png" class="brand-logo" alt="가시림" />
 </a>
-<section class="hero-slideshow hero-slideshow--video">
-  <div class="hero-video__container">
-    <div class="intro-hero" data-video>
-      <video class="intro-video" preload="auto" autoplay muted loop playsinline webkit-playsinline disablePictureInPicture controlsList="nodownload noplaybackrate noremoteplayback nofullscreen">
-        <source src="./assets/video/gasirim.mp4" type="video/mp4">
-        비디오를 재생할 수 없는 환경입니다.
-      </video>
-    </div>
-    <div class="embla__overlay">
-      <div class="embla__copy">
-        <h1>제주가 품은 정원,<br><span>마음을 여는 공간</span></h1>
-      </div>
-    </div>
+<section class="page-hero" aria-label="페이지 히어로 섹션">
+  <figure class="page-hero__media">
+    <img
+      src="./assets/img/main.jpg"
+      alt="가시림 정원 전경"
+      class="page-hero__image"
+      decoding="async"
+      loading="eager"
+      data-default-src="./assets/img/main.jpg"
+    />
+  </figure>
+  <div class="page-hero__overlay">
+    <h1 class="page-hero__title">가시림</h1>
   </div>
 </section>
+<script>
+  (function() {
+    const script = document.currentScript;
+    const includeRoot = script?.closest('[data-include]');
+    const host = includeRoot || script?.parentElement;
+    if (!host) return;
+
+    const hero = host.querySelector('.page-hero');
+    if (!hero) return;
+
+    const img = hero.querySelector('.page-hero__image');
+    const titleEl = hero.querySelector('.page-hero__title');
+
+    const dataset = includeRoot?.dataset || {};
+    const resolveAttr = (name, fallback = '') => {
+      if (dataset && dataset[name] !== undefined) return dataset[name];
+      if (host.hasAttribute(`data-${name.replace(/[A-Z]/g, m => '-' + m.toLowerCase())}`)) {
+        return host.getAttribute(`data-${name.replace(/[A-Z]/g, m => '-' + m.toLowerCase())}`);
+      }
+      return fallback;
+    };
+
+    const defaultTitle = titleEl?.textContent?.trim() || '가시림';
+    const resolvedTitle = resolveAttr('heroTitle', defaultTitle) || defaultTitle;
+    const defaultSrc = img?.dataset.defaultSrc || img?.getAttribute('src') || './assets/img/main.jpg';
+    const resolvedImage = resolveAttr('heroImage', defaultSrc) || defaultSrc;
+    const resolvedAlt = resolveAttr('heroAlt', resolvedTitle) || resolvedTitle;
+
+    if (img) {
+      img.src = resolvedImage;
+      img.alt = resolvedAlt;
+    }
+
+    if (titleEl) {
+      titleEl.textContent = resolvedTitle;
+    }
+  })();
+</script>

--- a/shop.html
+++ b/shop.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-shop.html"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
     <main class="shop-main" aria-labelledby="shop-heading">
       <section class="shop-overview">

--- a/공간소개.html
+++ b/공간소개.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="공간 소개" data-hero-image="assets/img/banner-fourseasons/fall.jpg" data-hero-alt="노을이 비치는 가시림 정원"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/단체문의.html
+++ b/단체문의.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="단체 문의" data-hero-image="assets/img/카페.jpg" data-hero-alt="가시림 카페 라운지 전경"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/둘러보기.html
+++ b/둘러보기.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="둘러보기" data-hero-image="assets/img/banner-fourseasons/winter.jpg" data-hero-alt="겨울 하늘 아래의 가시림 전경"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/방문.html
+++ b/방문.html
@@ -21,7 +21,7 @@
 </head>
 <body>
   <div class="page">
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="방문 안내" data-hero-image="assets/img/banner-fourseasons/fall.jpg" data-hero-alt="가을빛으로 물든 가시림 산책로"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="visit-main" aria-labelledby="visit-heading">

--- a/소개.html
+++ b/소개.html
@@ -24,7 +24,7 @@
   <div class="page">
 
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="가시림 소개" data-hero-image="assets/img/banner-fourseasons/summer.jpg" data-hero-alt="여름 햇살이 스며든 가시림 정원 전경"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main>
@@ -209,9 +209,9 @@
       <!-- 수목원 지도 -->
       <section id="수목원지도" class="tab-panel" role="tabpanel" tabindex="0" hidden>
         <!-- 지도 -->
-        <div class="intro-hero reveal parallax from-up">
-          <img src="assets/img/소개/지도.jpg" title="map">
-        </div>
+        <figure class="garden-map reveal from-up">
+          <img src="assets/img/소개/지도.jpg" alt="가시림 수목원 지도">
+        </figure>
         <!-- 스팟 리스트????? -->
       </section>
 

--- a/수목원지도.html
+++ b/수목원지도.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="수목원 지도" data-hero-image="assets/img/main.jpg" data-hero-alt="가시림 전경을 담은 항공 뷰"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/오시는길.html
+++ b/오시는길.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="오시는 길" data-hero-image="assets/img/banner-fourseasons/winter(withoutsnow).jpg" data-hero-alt="겨울 풍경의 가시림 숲길"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/이용안내.html
+++ b/이용안내.html
@@ -24,7 +24,7 @@
   <div class="page">
     
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="이용 안내" data-hero-image="assets/img/유리온실.jpg" data-hero-alt="가시림 유리 온실 내부"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <!-- 가시림 소개 -->

--- a/프로그램목록.html
+++ b/프로그램목록.html
@@ -23,16 +23,16 @@
 <body>
   <div class="page">
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="프로그램 목록" data-hero-image="assets/img/가든센터.jpg" data-hero-alt="가시림 가든센터 외관"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main>
       <!-- Navigation Tab -->
-      <nav class="intro-tabs data-tabs role="tablist" aria-label="프로그램 섹션">
-        <button class="tab-button active" type="button" role="tab" id="tab-space" aria-controls="All" aria-selected="true" data-hash="All">ALL</button>
-        <button class="tab-button" type="button" role="tab" id="tab-map" aria-controls="산책명상" aria-selected="false" data-hash="명상">산책명상</button>
-        <button class="tab-button" type="button" role="tab" id="tab-map" aria-controls="명상" aria-selected="false" data-hash="명상">명상</button>
-        <button class="tab-button" type="button" role="tab" id="tab-tour" aria-controls="원예" aria-selected="false" data-hash="원예">원예</button>
+      <nav class="intro-tabs" data-tabs role="tablist" aria-label="프로그램 섹션">
+        <button class="tab-button active" type="button" role="tab" id="tab-all" aria-controls="All" aria-selected="true" data-hash="All">ALL</button>
+        <button class="tab-button" type="button" role="tab" id="tab-walk" aria-controls="산책명상" aria-selected="false" data-hash="산책명상">산책명상</button>
+        <button class="tab-button" type="button" role="tab" id="tab-meditation" aria-controls="명상" aria-selected="false" data-hash="명상">명상</button>
+        <button class="tab-button" type="button" role="tab" id="tab-gardening" aria-controls="원예" aria-selected="false" data-hash="원예">원예</button>
       </nav>
 
       <!-- ALL -->
@@ -244,11 +244,11 @@
         </div>
       </section>
 
-     <!-- Modal -->
+      <!-- Modal -->
       <div class="program-modal" data-program-modal hidden>
         <div class="program-modal__backdrop" data-program-modal-close></div>
         <div class="program-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="program-modal-title" tabindex="-1">
-          <button class="program-modal__close" data-close>&times;</button>
+          <button class="program-modal__close" type="button" data-program-modal-close aria-label="닫기">&times;</button>
           <div class="program-modal__content" data-program-modal-content></div>
         </div>
       </div>

--- a/프로그램소개.html
+++ b/프로그램소개.html
@@ -23,7 +23,7 @@
 <body>
   <div class="page">
     <!-- Header -->
-    <div id="site-header" data-include="partials/header-site.html"></div>
+    <div id="site-header" data-include="partials/header-site.html" data-hero-title="프로그램 소개" data-hero-image="assets/img/유리온실2.jpg" data-hero-alt="프로그램이 열리는 가시림 온실 전경"></div>
     <div id="site-bar" data-include="partials/sticky-header-bar.html"></div>
 
     <main class="program-main" aria-labelledby="program-heading">
@@ -157,7 +157,7 @@
       <div class="program-modal" data-program-modal hidden>
         <div class="program-modal__backdrop" data-program-modal-close></div>
         <div class="program-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="program-modal-title" tabindex="-1">
-          <button class="program-modal__close" data-close>&times;</button>
+          <button class="program-modal__close" type="button" data-program-modal-close aria-label="닫기">&times;</button>
           <div class="program-modal__content" data-program-modal-content></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the shared site header with a configurable static hero and retain the video header only for the shop page
- realign the Embla overlay, enlarge the index intro video layout, and slow the intro gallery autoplay for smoother pacing
- refresh the 소개 공간 소개 grid and map presentation while fixing program tab navigation and modal close controls

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68df2d1b884c832188f445e3f6540940