### PR TITLE
Reimagine visit page structure and navigation

### DIFF
--- a/assets/css/globals.css
+++ b/assets/css/globals.css
@@ -64,5 +64,5 @@ h6 {
 }
 
 :root {
-  --page-pad: clamp(20px, 5vw, 72px);
+  --page-pad: clamp(18px, 4.5vw, 60px);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -873,6 +873,89 @@
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.18);
 }
 
+.intro-video__controls {
+  position: absolute;
+  right: clamp(12px, 3vw, 20px);
+  bottom: clamp(12px, 3vw, 20px);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.intro-video__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(16, 39, 27, 0.82);
+  color: #f4f7f4;
+  font-size: 0.92rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.intro-video__toggle:hover,
+.intro-video__toggle:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(16, 39, 27, 0.92);
+  box-shadow: 0 12px 28px rgba(16, 39, 27, 0.25);
+}
+
+.intro-video__toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.intro-video__toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.intro-video__toggle-icon svg {
+  width: 16px;
+  height: 16px;
+  display: none;
+}
+
+.intro-video__toggle-icon .icon--pause {
+  display: block;
+}
+
+.intro-video__toggle.is-paused .icon--pause {
+  display: none;
+}
+
+.intro-video__toggle.is-paused .icon--play {
+  display: block;
+}
+
+.intro-video__toggle-text {
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .intro-video__toggle {
+    padding: 8px 14px;
+    font-size: 0.85rem;
+  }
+
+  .intro-video__toggle-icon {
+    width: 14px;
+    height: 14px;
+  }
+
+  .intro-video__toggle-icon svg {
+    width: 14px;
+    height: 14px;
+  }
+}
+
 .hero {
   position: relative;
   aspect-ratio: 3 / 2;
@@ -2424,146 +2507,401 @@ body.modal-open {
 }
 /* ===== Visit page ===== */
 .visit-main {
-  padding: clamp(96px, 14vw, 180px) var(--page-pad) clamp(140px, 18vw, 220px);
+  padding: clamp(72px, 10vw, 120px) var(--page-pad) clamp(120px, 14vw, 160px);
   display: flex;
   flex-direction: column;
-  gap: clamp(80px, 12vw, 160px);
-  background: #fff;
+  gap: clamp(56px, 9vw, 88px);
+  background: #f7f9f6;
 }
 
-.visit-hero {
-  width: min(1200px, 100%);
+.visit-overview {
+  width: min(1080px, 100%);
   margin: 0 auto;
-  padding: clamp(40px, 6vw, 64px);
-  border-radius: 40px;
-  background:
-    radial-gradient(120% 120% at 0% 0%, rgba(184, 210, 194, 0.22), transparent 60%),
-    radial-gradient(110% 130% at 100% 0%, rgba(226, 236, 229, 0.28), transparent 70%),
-    #ffffff;
-  box-shadow: 0 32px 70px rgba(18, 44, 32, 0.12);
-}
-
-.visit-hero__copy {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(16px, 3vw, 24px);
-  color: #10271b;
-}
-
-.visit-hero__eyebrow {
-  font-size: 0.85rem;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  color: rgba(16, 39, 27, 0.55);
-}
-
-.visit-hero__lead {
-  font-size: 1.05rem;
-  line-height: 1.8;
-  color: rgba(16, 39, 27, 0.7);
-}
-
-.visit-section {
-  width: min(1200px, 100%);
-  margin: 0 auto;
-  padding: clamp(36px, 6vw, 56px);
-  border-radius: 36px;
-  background: #ffffff;
   display: grid;
-  gap: clamp(32px, 5vw, 48px);
+  gap: clamp(24px, 4vw, 36px);
 }
 
-.visit-section__header {
+.visit-overview__intro {
   display: grid;
   gap: 0.75rem;
 }
 
-.visit-section__label {
-  font-size: 0.82rem;
-  letter-spacing: 0.32em;
+.visit-overview__eyebrow {
+  font-size: 0.78rem;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
   font-weight: 600;
-  color: rgba(16, 39, 27, 0.45);
+  color: rgba(19, 41, 28, 0.52);
+}
+
+.visit-overview__title {
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 3.2rem);
+  font-weight: 600;
+  color: #13291c;
+}
+
+.visit-overview__lead {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: rgba(19, 41, 28, 0.68);
+}
+
+.visit-overview__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.visit-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(24, 66, 47, 0.22);
+  background: #ffffff;
+  color: #1d6040;
+  font-weight: 500;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.visit-tag:hover {
+  border-color: rgba(31, 109, 74, 0.45);
+  box-shadow: 0 10px 20px rgba(19, 41, 28, 0.08);
+}
+
+.visit-tag:focus-visible {
+  outline: 2px solid #1f6d4a;
+  outline-offset: 2px;
+}
+
+.visit-section {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(24px, 4vw, 36px);
+  padding-top: clamp(24px, 4vw, 32px);
+  border-top: 1px solid rgba(24, 66, 47, 0.12);
+}
+
+.visit-section--location {
+  padding-top: 0;
+  border-top: none;
+}
+
+.visit-section__header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.visit-section__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(19, 41, 28, 0.52);
+}
+
+.visit-section__title {
+  margin: 0;
+  font-size: clamp(1.7rem, 3.4vw, 2.2rem);
+  font-weight: 600;
+  color: #13291c;
 }
 
 .visit-section__lead {
-  font-size: 1.05rem;
+  margin: 0;
+  font-size: 1.02rem;
   line-height: 1.75;
-  color: rgba(16, 39, 27, 0.62);
+  color: rgba(19, 41, 28, 0.68);
 }
 
-.visit-grid {
+.visit-location__grid {
   display: grid;
-  gap: clamp(20px, 3vw, 28px);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(24px, 4vw, 40px);
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: start;
 }
 
-.visit-card {
-  display: grid;
-  gap: 1rem;
+.visit-location__image {
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  background: #dfe8e1;
+  min-height: clamp(280px, 45vw, 420px);
+  display: flex;
+  flex-direction: column;
+}
+
+.visit-location__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  flex: 1;
+}
+
+.visit-location__caption {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: rgba(19, 41, 28, 0.82);
+  color: #f4f6f2;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+.visit-hours-card {
+  background: #ffffff;
+  border: 1px solid rgba(24, 66, 47, 0.15);
+  border-radius: 24px;
   padding: clamp(24px, 4vw, 32px);
-  border-radius: 26px;
-  border: 1px solid rgba(32, 85, 65, 0.12);
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: 0 16px 40px rgba(19, 41, 28, 0.08);
 }
 
-.visit-badge {
+.visit-status {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
-  padding: 0.3rem 0.75rem;
+  gap: 0.45rem;
+  padding: 0.5rem 1rem;
   border-radius: 999px;
-  background: rgba(32, 85, 65, 0.12);
-  color: #205541;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
 }
 
-.visit-card__title {
-  font-weight: 600;
-  font-size: 1.2rem;
-  color: #10271b;
+.visit-status--open {
+  background: rgba(43, 140, 94, 0.12);
+  color: #1f6d4a;
+  border: 1px solid rgba(31, 109, 74, 0.35);
 }
 
-.visit-card p,
-.visit-card li {
+.visit-hours-list {
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.visit-hours-list__item {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.visit-hours-list__item dt {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgba(19, 41, 28, 0.75);
+}
+
+.visit-hours-list__item dd {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.7);
+}
+
+.visit-hours-note {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.68);
+}
+
+.visit-hours-note span[lang="en"] {
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.01em;
+}
+
+.visit-rate-table {
+  border: 1px solid rgba(24, 66, 47, 0.12);
+  border-radius: 18px;
+  overflow: hidden;
+  background: #ffffff;
+  box-shadow: 0 10px 26px rgba(19, 41, 28, 0.05);
+}
+
+.rate-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.96rem;
+}
+
+.rate-table thead {
+  background: #f0f5f2;
+  color: #1b3828;
+  font-weight: 600;
+}
+
+.rate-table th,
+.rate-table td {
+  padding: 0.85rem 1.1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(24, 66, 47, 0.12);
+}
+
+.rate-table tbody th {
+  font-weight: 600;
+  color: rgba(19, 41, 28, 0.8);
+}
+
+.rate-table tbody td {
+  color: rgba(19, 41, 28, 0.7);
+}
+
+.rate-table tbody tr:last-child th,
+.rate-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.visit-rate-note {
+  margin: 0;
+  font-size: 0.92rem;
+  color: rgba(19, 41, 28, 0.65);
+}
+
+.visit-rate-note a {
+  color: #1f6d4a;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.visit-rate-note a:hover {
+  text-decoration: underline;
+}
+
+.visit-guideline-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.visit-guideline {
+  border: 1px solid rgba(24, 66, 47, 0.14);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(19, 41, 28, 0.05);
+  overflow: hidden;
+}
+
+.visit-guideline summary {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  font-weight: 600;
   font-size: 1rem;
-  line-height: 1.7;
-  color: rgba(16, 39, 27, 0.68);
+  color: #1c3828;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  list-style: none;
 }
 
-.visit-card ul {
+.visit-guideline summary::-webkit-details-marker {
+  display: none;
+}
+
+.visit-guideline summary::after {
+  content: "›";
+  transform: rotate(90deg);
+  transition: transform 0.2s ease;
+  font-size: 1.2rem;
+  color: rgba(28, 56, 40, 0.5);
+}
+
+.visit-guideline[open] summary::after {
+  transform: rotate(-90deg);
+}
+
+.visit-guideline__body {
+  padding: 0 1.25rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.96rem;
+  line-height: 1.65;
+  color: rgba(19, 41, 28, 0.7);
+}
+
+.visit-guideline__body a {
+  color: #1f6d4a;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.visit-guideline__body a:hover {
+  text-decoration: underline;
+}
+
+.amenity-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.6rem;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.visit-card ul li::before {
-  content: "•";
-  color: #205541;
-  margin-right: 0.6rem;
-  font-weight: 700;
-}
-
-.visit-card ul li {
+.amenity-list__item {
   display: flex;
   align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(24, 66, 47, 0.12);
+  background: #ffffff;
+  box-shadow: 0 8px 24px rgba(19, 41, 28, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.visit-map {
+.amenity-list__item:hover {
+  border-color: rgba(31, 109, 74, 0.4);
+  box-shadow: 0 14px 32px rgba(19, 41, 28, 0.08);
+}
+
+.amenity-list__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(31, 109, 74, 0.12);
+  color: #1f6d4a;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+.amenity-list__icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.amenity-list__text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.72);
+}
+
+.visit-map__layout {
+  display: grid;
+  gap: clamp(24px, 4vw, 36px);
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: start;
+}
+
+.visit-map__frame {
   position: relative;
-  border-radius: 26px;
+  border-radius: 24px;
   overflow: hidden;
-  box-shadow: 0 32px 70px rgba(18, 44, 32, 0.14);
-  border: 1px solid rgba(32, 85, 65, 0.12);
-  min-height: 320px;
-  background: rgba(255, 255, 255, 0.8);
+  background: #dfe8e1;
+  min-height: clamp(280px, 45vw, 420px);
+  box-shadow: 0 18px 40px rgba(19, 41, 28, 0.12);
 }
 
-.visit-map iframe {
+.visit-map__frame iframe {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   border: 0;
@@ -2571,60 +2909,90 @@ body.modal-open {
 
 .visit-map__badge {
   position: absolute;
-  top: 18px;
-  right: 18px;
-  padding: 0.45rem 1.1rem;
+  top: 20px;
+  left: 20px;
+  padding: 0.4rem 1rem;
   border-radius: 999px;
-  background: rgba(16, 29, 22, 0.85);
-  color: #f2f2ed;
+  background: rgba(19, 41, 28, 0.85);
+  color: #f5f8f4;
   font-size: 0.8rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.visit-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.visit-map__details {
+  background: #ffffff;
+  border: 1px solid rgba(24, 66, 47, 0.12);
+  border-radius: 20px;
+  padding: clamp(22px, 4vw, 30px);
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 12px 28px rgba(19, 41, 28, 0.08);
 }
 
-.visit-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.8rem 1.5rem;
-  border-radius: 999px;
-  font-size: 0.95rem;
+.visit-map__title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
   font-weight: 600;
-  text-decoration: none;
-  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, color 200ms ease;
+  color: #1b3828;
+}
+
+.visit-map__address {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.68);
+}
+
+.visit-directions {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.visit-directions__row {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.visit-directions__row dt {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgba(19, 41, 28, 0.75);
+}
+
+.visit-directions__row dd {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.7);
 }
 
 .contact-grid {
   display: grid;
   gap: clamp(20px, 3vw, 28px);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .contact-card {
   padding: clamp(22px, 3.5vw, 28px);
-  border-radius: 24px;
-  border: 1px solid rgba(32, 85, 65, 0.12);
+  border-radius: 18px;
+  border: 1px solid rgba(24, 66, 47, 0.12);
+  background: #ffffff;
   display: grid;
   gap: 0.6rem;
+  box-shadow: 0 10px 24px rgba(19, 41, 28, 0.06);
 }
 
 .contact-card span {
   font-size: 0.82rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(16, 39, 27, 0.45);
+  color: rgba(19, 41, 28, 0.5);
   font-weight: 600;
 }
 
 .contact-card a {
-  color: #205541;
+  color: #1f6d4a;
   font-weight: 600;
   text-decoration: none;
 }
@@ -2633,14 +3001,47 @@ body.modal-open {
   text-decoration: underline;
 }
 
+.contact-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(19, 41, 28, 0.68);
+}
+
+@media (max-width: 960px) {
+  .visit-location__grid,
+  .visit-map__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 720px) {
-  .visit-section {
-    padding: clamp(28px, 8vw, 40px);
+  .visit-main {
+    gap: clamp(48px, 12vw, 72px);
+  }
+
+  .visit-overview__tags {
+    gap: 0.6rem;
+  }
+
+  .visit-tag {
+    font-size: 0.9rem;
+    padding: 0.5rem 0.9rem;
   }
 
   .visit-map__badge {
     position: static;
-    margin: 16px;
     display: inline-flex;
+  }
+}
+
+@media (max-width: 540px) {
+  .visit-tag {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .visit-location__caption {
+    font-size: 0.78rem;
   }
 }

--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -1,5 +1,5 @@
 :root {
-  --page-pad: clamp(20px, 5vw, 72px);
+  --page-pad: clamp(18px, 4.5vw, 60px);
   --section-gap: clamp(24px, 6vw, 64px);
   /* Colors */
   --color-bg: #ffffff;

--- a/index.html
+++ b/index.html
@@ -40,6 +40,19 @@
           <source src="assets/video/gasirim.mp4" type="video/mp4">
           비디오를 재생할 수 없는 환경입니다.
         </video>
+        <div class="intro-video__controls">
+          <button type="button" class="intro-video__toggle" data-video-toggle aria-pressed="false">
+            <span class="intro-video__toggle-icon" aria-hidden="true">
+              <svg class="icon--pause" viewBox="0 0 24 24" focusable="false">
+                <path d="M7 4h3v16H7zM14 4h3v16h-3z" fill="currentColor" />
+              </svg>
+              <svg class="icon--play" viewBox="0 0 24 24" focusable="false">
+                <path d="M8 5v14l10-7z" fill="currentColor" />
+              </svg>
+            </span>
+            <span class="intro-video__toggle-text">일시 정지</span>
+          </button>
+        </div>
       </div>
 
       <div class="article article-container reveal from-left">

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -3,7 +3,7 @@
   <div class="footer-divider"></div>
 
   <div class="footer-left">
-    <img class="footer-logo" src="./assets/img/가시림로고_텍스트.png" alt="가시림 로고" width="160" height="48" />
+    <img class="footer-logo" src="./assets/img/logo_text_white.png" alt="가시림 로고" width="160" height="48" />
 
     <address class="footer-contact">
       <span class="footer-contact__item">전화 | <a href="tel:07042810906">070-4281-0906</a></span>
@@ -22,10 +22,10 @@
           <path d="M21.6 6.2a2.5 2.5 0 0 0-1.76-1.77C18.1 4 12 4 12 4s-6.1 0-7.84.43A2.5 2.5 0 0 0 2.4 6.2 26.7 26.7 0 0 0 2 12a26.7 26.7 0 0 0 .4 5.8 2.5 2.5 0 0 0 1.76 1.77C5.9 20 12 20 12 20s6.1 0 7.84-.43A2.5 2.5 0 0 0 21.6 17.8 26.7 26.7 0 0 0 22 12a26.7 26.7 0 0 0-.4-5.8ZM10.5 15.3V8.7L16 12Z"/>
         </svg>
       </a>
-      <a href="https://pf.kakao.com/" aria-label="KakaoTalk" class="social-btn" target="_blank" rel="noopener noreferrer">
+      <a href="https://www.facebook.com/" aria-label="Facebook" class="social-btn" target="_blank" rel="noopener noreferrer">
         <svg viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false">
-          <path d="M12 3.5c-5.11 0-9.25 3.25-9.25 7.26 0 2.66 1.9 4.97 4.75 6.16L6 21.5l4.4-3.06c.51.06 1.03.09 1.56.09 5.11 0 9.25-3.25 9.25-7.26S17.11 3.5 12 3.5Z"/>
-          <path d="M8.1 10.06h1.34v3.27H8.1Zm3.06 0h1.24l.02 1.73 1.41-1.73h1.35l-1.63 1.87 1.7 2.01h-1.42l-1.39-1.69-.04 1.69h-1.24Zm-4.82 0H5v3.27h1.34Zm9.68 0h-1.44v3.27h1.44Zm-5.73-.88a.88.88 0 1 1-.88-.88.88.88 0 0 1 .88.88Z" fill="#fff"/>
+          <path d="M13.34 21h-2.78v-7.49H8.6v-2.4h1.96V9.23c0-2 1.3-3.73 4.12-3.73 1.17 0 2.03.11 2.03.11l-.07 2.27s-.88-.01-1.83-.01c-1.03 0-1.19.47-1.19 1.24v1.4h3.08l-.13 2.4h-2.95V21Z"/>
+          <path d="M12 22.75A10.75 10.75 0 1 1 22.75 12 10.76 10.76 0 0 1 12 22.75Zm0-19.5A8.75 8.75 0 1 0 20.75 12 8.76 8.76 0 0 0 12 3.25Z"/>
         </svg>
       </a>
     </div>

--- a/방문.html
+++ b/방문.html
@@ -26,63 +26,210 @@
 
     <main class="visit-main" aria-labelledby="visit-heading">
 
-      <section id="이용안내" class="visit-section" aria-labelledby="section-usage">
-        <div class="visit-section__header">
-          <span class="visit-section__label">Information</span>
-          <h2 id="section-usage" class="visit-section__title">이용 시간 및 요금 안내</h2>
-          <p class="visit-section__lead">사계절 내내 열린 가시림에서는 계절마다 다른 자연의 표정을 만나실 수 있습니다. 여유로운 방문을 위해 운영 시간과 요금을 미리 확인해 주세요.</p>
+      <section class="visit-overview" aria-labelledby="visit-heading">
+        <div class="visit-overview__intro">
+          <span class="visit-overview__eyebrow">Plan your visit</span>
+          <h1 id="visit-heading" class="visit-overview__title">방문 안내</h1>
+          <p class="visit-overview__lead">가시림 수목원에 오시는 길과 운영 정보를 한눈에 확인하세요. 방문 목적에 맞는 안내를 빠르게 찾아볼 수 있도록 주요 섹션을 정리했습니다.</p>
         </div>
-        <div class="visit-grid">
-          <article class="visit-card">
-            <span class="visit-badge">운영 시간</span>
-            <p class="visit-card__title">매일 09:30 – 18:00 (수요일 제외)</p>
-            <ul>
-              <li>마지막 입장 17:00</li>
-              <li>사전 예약 없이 현장 입장 가능</li>
-            </ul>
-            <p>폭우나 강풍 등 기상 상황에 따라 운영 시간이 변동될 수 있으니 방문 전 공지 사항을 확인해 주세요.</p>
-          </article>
-          <article class="visit-card">
-            <span class="visit-badge">이용 요금</span>
-            <p class="visit-card__title">연령별 요금 안내</p>
-            <ul>
-              <li>일반: 6,000원</li>
-              <li>어린이·청소년: 5,000원</li>
-              <li>우대 할인: 5,000원 (36개월 미만 무료)/li>
-              <li>무료 입장: 영유아·가시림 주민/li>
-            </ul>
-          </article>
-          <article class="visit-card">
-            <span class="visit-badge">방문 안내</span>
-            <p class="visit-card__title">편의 사항</p>
-            <ul>
-              <li>무료 주차장이 구비되어 있습니다</li>
-              <li>반려동물은 목줄 착용 시 동반 입장이 가능합니다 (중형견까지 가능)</li>
-              <li>지역화폐 (탐나는전) 사용 가능합니다</li>
-              <li>휠체어 입장 가능합니다 (이용 가능한 산책로가 한정적일 수 있음)</li>
-              <li>계절별 추천 코스를 매표소에서 받내보세요</li>
-            </ul>
+        <nav class="visit-overview__tags" aria-label="방문 안내 섹션">
+          <a class="visit-tag" href="#visit-location">위치 및 운영</a>
+          <a class="visit-tag" href="#visit-tickets">이용 요금</a>
+          <a class="visit-tag" href="#visit-guides">방문 전 알아두기</a>
+          <a class="visit-tag" href="#visit-amenities">편의 시설</a>
+          <a class="visit-tag" href="#visit-directions">오시는 길</a>
+          <a class="visit-tag" href="#visit-contact">문의</a>
+        </nav>
+      </section>
+
+      <section id="visit-location" class="visit-section visit-section--location" aria-labelledby="section-location">
+        <div class="visit-section__header">
+          <span class="visit-section__label">Locations &amp; Hours</span>
+          <h2 id="section-location" class="visit-section__title">위치 및 운영 안내</h2>
+          <p class="visit-section__lead">사계절 내내 이어지는 가시림의 일상을 가까이에서 만나보세요. 운영 시간과 휴무일, 입장 마감 정보를 미리 확인하시면 더욱 여유로운 방문을 도와드립니다.</p>
+        </div>
+        <div class="visit-location__grid">
+          <figure class="visit-location__image">
+            <img src="assets/img/유리온실.jpg" alt="가시림 수목원의 온실 외관" loading="lazy" />
+            <figcaption class="visit-location__caption">가시림 수목원 유리온실 전경</figcaption>
+          </figure>
+          <article class="visit-hours-card" aria-label="운영 정보">
+            <span class="visit-status visit-status--open">오늘 운영 중 · 09:30 – 18:00</span>
+            <dl class="visit-hours-list">
+              <div class="visit-hours-list__item">
+                <dt>정규 운영</dt>
+                <dd>매일 09:30 – 18:00</dd>
+              </div>
+              <div class="visit-hours-list__item">
+                <dt>휴무</dt>
+                <dd>매주 수요일 정기 휴무 (시설 점검)</dd>
+              </div>
+              <div class="visit-hours-list__item">
+                <dt>입장 마감</dt>
+                <dd>17:00 (프로그램 예약 시 시작 10분 전 도착 권장)</dd>
+              </div>
+              <div class="visit-hours-list__item">
+                <dt>현장 안내</dt>
+                <dd>예약 없이 방문 가능하며, 기상 상황에 따라 일부 구역 운영이 변경될 수 있습니다.</dd>
+              </div>
+            </dl>
+            <p class="visit-hours-note">네비게이션에서 ‘가시림 수목원’을 검색하거나 주소 <span lang="en">3266 Gasi-ri, Pyoseon-myeon</span>을 입력해 주세요.</p>
           </article>
         </div>
       </section>
 
-      <section id="오시는길" class="visit-section" aria-labelledby="section-directions">
+      <section id="visit-tickets" class="visit-section visit-section--tickets" aria-labelledby="section-tickets">
+        <div class="visit-section__header">
+          <span class="visit-section__label">Tickets</span>
+          <h2 id="section-tickets" class="visit-section__title">이용 요금</h2>
+          <p class="visit-section__lead">현장에서 카드, 모바일 결제, 지역화폐(탐나는전)를 모두 지원합니다. 단체 예약은 사전 문의해 주시면 맞춤 견적을 안내드립니다.</p>
+        </div>
+        <div class="visit-rate-table" role="region" aria-labelledby="section-tickets">
+          <table class="rate-table">
+            <caption class="sr-only">가시림 수목원 이용 요금표</caption>
+            <thead>
+              <tr>
+                <th scope="col">구분</th>
+                <th scope="col">요금</th>
+                <th scope="col">비고</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">일반</th>
+                <td>6,000원</td>
+                <td>만 19세 이상</td>
+              </tr>
+              <tr>
+                <th scope="row">어린이·청소년</th>
+                <td>5,000원</td>
+                <td>만 3세 – 18세</td>
+              </tr>
+              <tr>
+                <th scope="row">우대 할인</th>
+                <td>5,000원</td>
+                <td>만 65세 이상, 국가유공자, 장애인 (증빙 지참)</td>
+              </tr>
+              <tr>
+                <th scope="row">영유아·가시리 주민</th>
+                <td>무료</td>
+                <td>36개월 미만, 가시리 주민 (신분증 지참)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="visit-rate-note">단체(20인 이상) 또는 프로그램 연계 방문 시 <a href="#visit-contact">문의 섹션</a>을 통해 맞춤 상담을 신청해 주세요.</p>
+      </section>
+
+      <section id="visit-guides" class="visit-section visit-section--guides" aria-labelledby="section-guides">
+        <div class="visit-section__header">
+          <span class="visit-section__label">Know Before You Go</span>
+          <h2 id="section-guides" class="visit-section__title">방문 전 알아두기</h2>
+          <p class="visit-section__lead">편안한 방문을 위해 꼭 확인해야 할 사항을 정리했습니다. 궁금한 내용을 펼쳐 보세요.</p>
+        </div>
+        <div class="visit-guideline-list">
+          <details class="visit-guideline" open>
+            <summary>입장 및 관람</summary>
+            <div class="visit-guideline__body">
+              <p>입장권은 현장 매표소에서 발권하며 재입장은 당일에 한해 가능합니다. 우천 시 실내 온실과 전시관을 우선 이용하시길 권장합니다.</p>
+            </div>
+          </details>
+          <details class="visit-guideline">
+            <summary>체험 프로그램</summary>
+            <div class="visit-guideline__body">
+              <p>원예 클래스, 숲 해설 등 프로그램은 사전 예약제로 운영됩니다. 예약 확정 후 방문해 주시면 준비된 재료와 안내를 제공해 드립니다.</p>
+            </div>
+          </details>
+          <details class="visit-guideline">
+            <summary>촬영 및 대관</summary>
+            <div class="visit-guideline__body">
+              <p>스냅 촬영, 방송 촬영 등 상업 목적 촬영은 허가가 필요합니다. 일정과 목적을 <a href="#visit-contact">문의 채널</a>로 보내주시면 담당자가 확인 후 회신드립니다.</p>
+            </div>
+          </details>
+          <details class="visit-guideline">
+            <summary>안전 수칙</summary>
+            <div class="visit-guideline__body">
+              <p>관람 동선 내에서는 지정된 산책로를 이용해 주시고, 식물 채집 및 반출은 금지되어 있습니다. 반려동물은 목줄 착용 및 배변 봉투 지참이 필수입니다.</p>
+            </div>
+          </details>
+        </div>
+      </section>
+
+      <section id="visit-amenities" class="visit-section visit-section--amenities" aria-labelledby="section-amenities">
+        <div class="visit-section__header">
+          <span class="visit-section__label">Amenities</span>
+          <h2 id="section-amenities" class="visit-section__title">편의 시설</h2>
+          <p class="visit-section__lead">방문객을 위한 주요 편의 사항을 확인하세요. 아이콘을 눌러 상세 설명을 읽어볼 수 있습니다.</p>
+        </div>
+        <ul class="amenity-list">
+          <li class="amenity-list__item">
+            <span class="amenity-list__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" /><path d="M10.2 7.2h2.7a2.4 2.4 0 1 1 0 4.8h-2.7v4.8" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" /></svg>
+            </span>
+            <span class="amenity-list__text">무료주차장 완비 — 주차 걱정 없이 방문하세요.</span>
+          </li>
+          <li class="amenity-list__item">
+            <span class="amenity-list__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false"><circle cx="7.8" cy="10" r="1.5" fill="currentColor" /><circle cx="10.4" cy="7.2" r="1.4" fill="currentColor" /><circle cx="13.6" cy="7.2" r="1.4" fill="currentColor" /><circle cx="16.2" cy="10" r="1.5" fill="currentColor" /><path d="M12 12.7c-1.8 0-3.1 1.1-3.1 2.7 0 1.2.8 2.1 1.9 2.7.7.4 1.7.4 2.4 0 1.1-.6 1.9-1.5 1.9-2.7 0-1.6-1.3-2.7-3.1-2.7Z" fill="currentColor" /></svg>
+            </span>
+            <span class="amenity-list__text">반려동물 동반 가능 — 목줄 착용 시 중형견까지 입장 가능합니다.</span>
+          </li>
+          <li class="amenity-list__item">
+            <span class="amenity-list__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false"><rect x="3" y="6" width="18" height="12" rx="2.5" ry="2.5" fill="none" stroke="currentColor" stroke-width="1.6" /><path d="M3 10.5h18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M6.5 15h4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M15.5 15h2.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /></svg>
+            </span>
+            <span class="amenity-list__text">지역화폐 및 다양한 결제 수단 지원 — 탐나는전, 카드, 모바일 결제 가능.</span>
+          </li>
+          <li class="amenity-list__item">
+            <span class="amenity-list__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="5.5" r="2" fill="currentColor" /><path d="M8 9.5h8M12 9.5l2.7 4.6h3.1" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /><path d="M12 11.6 10 16.2a3.3 3.3 0 1 0 1.6.7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /></svg>
+            </span>
+            <span class="amenity-list__text">휠체어 접근 가능 — 완만한 진입로와 보조 동선을 안내해 드립니다.</span>
+          </li>
+          <li class="amenity-list__item">
+            <span class="amenity-list__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false"><path d="M12 3.2a6.3 6.3 0 0 0-6.3 6.3c0 3.2 2.6 6.3 6.3 11.3 3.7-5 6.3-8.1 6.3-11.3A6.3 6.3 0 0 0 12 3.2Zm0 9.2a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor" /></svg>
+            </span>
+            <span class="amenity-list__text">계절별 추천 코스 — 매표소에서 맞춤 방문 지도를 받아보세요.</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="visit-directions" class="visit-section visit-section--map" aria-labelledby="section-directions">
         <div class="visit-section__header">
           <span class="visit-section__label">Directions</span>
           <h2 id="section-directions" class="visit-section__title">오시는 길</h2>
           <p class="visit-section__lead">네비게이션에서 ‘가시림’ 또는 ‘가시림 수목원’을 검색해 주세요. 제주공항에서 자동차로 약 1시간 거리에 위치해 있습니다.</p>
         </div>
-        <div class="visit-grid">
-          <div class="visit-map">
+        <div class="visit-map__layout">
+          <figure class="visit-map__frame">
             <div class="visit-map__badge">3266 가시리</div>
-            <iframe title="가시림 위치 지도" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade" src="https://maps.google.com/maps?q=3266%20Gasi-ri,%20Pyoseon-myeon,%20%ED%8A%B9%EB%B3%84%EC%9E%90%EC%B9%98%EB%8F%84,%20Seogwipo,%20Jeju-do,%20South%20Korea&output=embed"></iframe>
-          </div>
+            <iframe title="가시림 위치 지도" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade" src="https://maps.google.com/maps?q=3266%20Gasi-ri,%20Pyoseon-myeon,%20%ED%8A%B9%EB%B3%84%EC%9E%90%EC%B9%98%EB%8F%84,%20Seogwipo,%20Jeju-do,%20South%20Korea&z=16&output=embed"></iframe>
+          </figure>
+          <aside class="visit-map__details">
+            <h3 class="visit-map__title">가시림 수목원 안내</h3>
+            <p class="visit-map__address">제주특별자치도 서귀포시 표선면 녹산로5번길 171</p>
+            <dl class="visit-directions">
+              <div class="visit-directions__row">
+                <dt>자동차</dt>
+                <dd>제주국제공항 → 번영로 → 표선면 방면 약 60분 소요 (주차장 무료)</dd>
+              </div>
+              <div class="visit-directions__row">
+                <dt>버스</dt>
+                <dd>201, 221 번 노선 이용 후 ‘가시리입구’ 하차, 도보 10분</dd>
+              </div>
+              <div class="visit-directions__row">
+                <dt>택시</dt>
+                <dd>공항에서 약 35,000원 내외, 기사님께 ‘가시림 수목원’으로 말씀해 주세요.</dd>
+              </div>
+            </dl>
+          </aside>
         </div>
       </section>
 
-      <section id="단체문의" class="visit-section" aria-labelledby="section-group">
+      <section id="visit-contact" class="visit-section visit-section--contact" aria-labelledby="section-group">
         <div class="visit-section__header">
-          <span class="visit-section__label">Group Booking</span>
+          <span class="visit-section__label">Contact</span>
           <h2 id="section-group" class="visit-section__title">단체 예약 및 대관 문의</h2>
           <p class="visit-section__lead">기업 워크숍, 원예 클래스, 스냅 촬영 등 목적에 맞춘 맞춤형 프로그램과 공간을 제안해 드립니다. 방문 희망일과 인원, 요청 사항을 남겨 주시면 전담 매니저가 빠르게 연락드립니다.</p>
         </div>


### PR DESCRIPTION
## Summary
- rebuild the 방문 안내 page around a top-level overview with section tags, refreshed location/hours presentation, expandable guidelines, and reorganized amenities/contact blocks
- update visit-page styling to support the new layout with simplified cards, table treatments, and responsive grids inspired by the reference design

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68df64e4851c8321b32d30eb876a01a6